### PR TITLE
fix: remove explicit msvcrtd link that causes CRT mismatch

### DIFF
--- a/llama-cpp-sys-4/build.rs
+++ b/llama-cpp-sys-4/build.rs
@@ -1275,10 +1275,11 @@ fn main() {
         }
     }
 
-    // msvcrtd is the MSVC debug CRT — it does not exist in MinGW toolchains.
-    if cfg!(debug_assertions) && target.contains("windows-msvc") {
-        println!("cargo:rustc-link-lib=dylib=msvcrtd");
-    }
+    // Removed: Rust already links the appropriate CRT. Explicitly linking
+    // msvcrtd causes CRT mismatch when another crate (e.g. whisper-rs) links
+    // the release CRT — both msvcrt and msvcrtd get loaded into the same
+    // process, corrupting the file descriptor table and causing
+    // `_osfile(fh) & FOPEN` assertion failures in read.cpp.
 
     // macOS frameworks and libc++
     if target.contains("apple") {


### PR DESCRIPTION
## Problem

In debug builds on Windows MSVC, `build.rs` explicitly links `msvcrtd` (debug CRT):

```rust
if cfg!(debug_assertions) && target.contains("windows-msvc") {
    println!("cargo:rustc-link-lib=dylib=msvcrtd");
}
```

Rust already links the appropriate CRT (`msvcrt`). This explicit `msvcrtd` link causes **both** `msvcrt.dll` (release) and `msvcrtd.dll` (debug) to be loaded into the same process.

When combined with any other crate that uses the release CRT (e.g. `whisper-rs`, which also bundles ggml with Vulkan), the two CRT instances have separate file descriptor tables. This corrupts CRT internal state, causing:

```
Debug Assertion Failed!
File: minkernel\crts\src\appcrt\lowio\read.cpp
Line: 381
Expression: _osfile(fh) & FOPEN
```

## Fix

Remove the explicit `msvcrtd` link. Rust handles CRT linking — no manual intervention needed.

## Testing

Built and tested with `whisper-rs` (v0.13, Vulkan) + `llama-cpp-4` (v0.2.12, Vulkan + dynamic-link) in the same binary. Without this fix, whisper crashes on model load. With this fix, both work correctly.