### PR TITLE
Add transactional speculation and tensor mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   state, checked topology/capacity construction, and contained C++ failures.
 - Transactional tensor capture/write-back with decode lifecycle hooks and a
   documented safe ownership boundary.
+- Allocation-reusing tokenization and raw-token-piece sinks, plus a
+  count-only tokenizer query for coordinator-owned bounded utility work.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Added
+
+- Lifetime-bound, non-thread-transferable MTP and EAGLE-3 sessions with
+  bounded prompt/proposal/state inputs, exact implementation continuation
+  state, checked topology/capacity construction, and contained C++ failures.
+- Transactional tensor capture/write-back with decode lifecycle hooks and a
+  documented safe ownership boundary.
+
+### Changed
+
+- Forward-port the binding and native patches to literal llama.cpp revision
+  `f87067841bac583bc089a225382248d857791ca8`, including EAGLE-3 v3 target
+  extraction for `gpt-oss`.
+- Build `llama-common` for the speculative shim and verify the patched source
+  postcondition even when an OUT_DIR sentinel or shared CMake cache exists.
+- Resolve shared runtime assets against Cargo's active target/profile
+  directory even when `build.build-dir` places `OUT_DIR` elsewhere.
+- Honor the documented static-link default in `llama-cpp-4`; shared
+  `libllama` artifacts now require the explicit `dynamic-link` feature.
+- Fall back from unverified prebuilt archives to a source build; explicit
+  unverifiable `LLAMA_PREBUILT_DIR` inputs now fail closed.
+
 ## [0.4.2] - 2026-07-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@
 - Allocation-reusing tokenization and raw-token-piece sinks, plus a
   count-only tokenizer query for coordinator-owned bounded utility work.
 
+### Breaking
+
+- `MtpSession` and `Eagle3Session` now exclusively borrow mutable target and
+  draft contexts, are neither `Send` nor `Sync`, and report lifecycle failures
+  through typed `Result` values. Existing speculative loops must use the
+  session's context accessors and checked decode helpers.
+- `LlamaContextParams::with_tensor_capture` is now `unsafe` because it installs
+  a pointer to caller-borrowed callback state without retaining that borrow.
+  New code should use the safe, owned `with_tensor_transactions` API.
+- The default feature set no longer enables `dynamic-link`. Callers that
+  require shared llama.cpp libraries must select that feature explicitly.
+
 ### Changed
 
 - Forward-port the binding and native patches to literal llama.cpp revision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@
 - `LlamaContextParams::with_tensor_capture` is now `unsafe` because it installs
   a pointer to caller-borrowed callback state without retaining that borrow.
   New code should use the safe, owned `with_tensor_transactions` API.
-- The default feature set no longer enables `dynamic-link`. Callers that
-  require shared llama.cpp libraries must select that feature explicitly.
 
 ### Changed
 
@@ -33,8 +31,6 @@
   postcondition even when an OUT_DIR sentinel or shared CMake cache exists.
 - Resolve shared runtime assets against Cargo's active target/profile
   directory even when `build.build-dir` places `OUT_DIR` elsewhere.
-- Honor the documented static-link default in `llama-cpp-4`; shared
-  `libllama` artifacts now require the explicit `dynamic-link` feature.
 - Fall back from unverified prebuilt archives to a source build; explicit
   unverifiable `LLAMA_PREBUILT_DIR` inputs now fail closed.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
 dependencies = [
  "bytestring",
- "cfg-if 1.0.4",
+ "cfg-if",
  "http 0.2.12",
  "regex",
  "regex-lite",
@@ -185,8 +185,8 @@ dependencies = [
  "actix-web-codegen",
  "bytes",
  "bytestring",
- "cfg-if 1.0.4",
- "cookie",
+ "cfg-if",
+ "cookie 0.16.2",
  "derive_more",
  "encoding_rs",
  "foldhash 0.2.0",
@@ -319,38 +319,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "batched-bench"
 version = "0.4.2"
 dependencies = [
@@ -408,7 +382,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -426,60 +400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "blake3"
-version = "1.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if 1.0.4",
- "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "bon"
-version = "3.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
-dependencies = [
- "bon-macros",
- "rustversion",
-]
-
-[[package]]
-name = "bon-macros"
-version = "3.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
-dependencies = [
- "darling",
- "ident_case",
- "prettyplease",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -504,17 +430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde_core",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,10 +442,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.1"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -582,12 +497,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -604,8 +513,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures 0.3.0",
+ "cfg-if",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -721,31 +630,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "const-str"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
-
-[[package]]
-name = "const_panic"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
-dependencies = [
- "typewit",
-]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -765,6 +665,35 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie 0.18.1",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -794,24 +723,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "countio"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9702aee5d1d744c01d82f6915644f950f898e014903385464c773b96fefdecb"
-dependencies = [
- "futures-io",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,23 +737,8 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -873,31 +769,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "ctor"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb"
-dependencies = [
- "link-section",
- "linktime-proc-macro",
 ]
 
 [[package]]
@@ -944,6 +820,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,23 +863,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1069,12 +945,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1135,7 +1017,7 @@ version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
 ]
 
@@ -1181,6 +1063,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1286,34 +1183,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "gearhash"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cf82cf76cd16485e56295a1377c775ce708c9f1a0be6b029076d60a245d213"
-dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1323,7 +1201,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -1337,34 +1215,12 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if 1.0.4",
- "js-sys",
+ "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "git-version"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
-dependencies = [
- "git-version-macro",
-]
-
-[[package]]
-name = "git-version-macro"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1372,19 +1228,6 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
-
-[[package]]
-name = "globset"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "h2"
@@ -1440,67 +1283,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
-name = "heapify"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hf-hub"
-version = "1.0.0"
+name = "hermit-abi"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ccb6bcc85dec15413ef5949879f9a5497ca4568ed702547eb83fac23376e5c"
-dependencies = [
- "base64",
- "bon",
- "bytes",
- "futures",
- "getrandom 0.2.17",
- "globset",
- "hf-xet",
- "hyper",
- "pathdiff",
- "percent-encoding",
- "reqwest",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tokio-retry",
- "tokio-util",
- "tracing",
- "url",
- "wasm-bindgen-futures",
-]
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hf-xet"
-version = "1.5.3"
+name = "hf-hub"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba6e94f549dbe76ced2c56ada52958e63f9056afabb21f74aae1b5777c8cd5d"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
- "async-trait",
- "bytes",
+ "dirs",
+ "futures",
  "http 1.4.0",
- "more-asserts",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "num_cpus",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
  "serde",
+ "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "tokio-util",
- "tokio_with_wasm",
- "tracing",
- "uuid",
- "xet-client",
- "xet-core-structures",
- "xet-data",
- "xet-runtime",
+ "ureq 3.3.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1560,12 +1375,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,6 +1417,22 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1817,6 +1642,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,15 +1686,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,7 +1698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
- "cfg-if 1.0.4",
+ "cfg-if",
  "combine",
  "jni-sys 0.3.1",
  "log",
@@ -1922,28 +1751,11 @@ version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "konst"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
-dependencies = [
- "const_panic",
- "konst_proc_macros",
- "typewit",
-]
-
-[[package]]
-name = "konst_proc_macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "language-tags"
@@ -1975,7 +1787,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "windows-link",
 ]
 
@@ -1987,18 +1799,6 @@ checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "link-section"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
-
-[[package]]
-name = "linktime-proc-macro"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2040,7 +1840,7 @@ dependencies = [
  "glob",
  "patch-apply",
  "tar",
- "ureq",
+ "ureq 2.12.1",
  "winreg",
 ]
 
@@ -2083,15 +1883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "lz4_flex"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,16 +1902,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -2146,15 +1927,9 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "more-asserts"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "mtmd"
@@ -2177,6 +1952,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,15 +1987,6 @@ dependencies = [
  "bytecount",
  "memchr",
  "nom",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2231,31 +2014,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
+name = "num_cpus"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
+ "hermit-abi",
  "libc",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-system-configuration"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
-dependencies = [
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2271,12 +2036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "oneshot"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
-
-[[package]]
 name = "openai-server"
 version = "0.4.2"
 dependencies = [
@@ -2289,12 +2048,37 @@ dependencies = [
  "futures-util",
  "hf-hub",
  "llama-cpp-4",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2304,19 +2088,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "parking_lot"
@@ -2334,7 +2121,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -2353,10 +2140,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
+name = "pem-rfc7468"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2374,26 +2164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2174,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -2581,15 +2357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "redb"
-version = "3.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2413,49 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2666,7 +2476,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2675,33 +2484,16 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "reqwest-middleware"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 1.4.0",
- "reqwest",
- "thiserror 2.0.19",
- "tower-service",
 ]
 
 [[package]]
@@ -2711,7 +2503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if 1.0.4",
+ "cfg-if",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
@@ -2836,12 +2628,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "safe-transmute"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,17 +2733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,41 +2750,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
- "sha2-asm",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
-dependencies = [
- "cc",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3019,17 +2762,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shellexpand"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
-dependencies = [
- "bstr",
- "dirs",
- "os_str_bytes",
 ]
 
 [[package]]
@@ -3125,6 +2857,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "split-model-example"
 version = "0.4.2"
 dependencies = [
@@ -3139,22 +2882,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "statrs"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
-dependencies = [
- "approx",
- "num-traits",
-]
 
 [[package]]
 name = "strsim"
@@ -3178,12 +2905,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -3225,20 +2946,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows",
 ]
 
 [[package]]
@@ -3332,7 +3039,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3429,13 +3136,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-retry"
-version = "0.3.2"
+name = "tokio-native-tls"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
- "pin-project-lite",
- "rand 0.10.1",
+ "native-tls",
  "tokio",
 ]
 
@@ -3460,30 +3166,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio_with_wasm"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e40fbbbd95441133fe9483f522db15dbfd26dc636164ebd8f2dd28759a6aa6"
-dependencies = [
- "js-sys",
- "tokio",
- "tokio_with_wasm_proc",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "tokio_with_wasm_proc"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
-dependencies = [
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3544,19 +3226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-appender"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
-dependencies = [
- "crossbeam-channel",
- "symlink",
- "thiserror 2.0.19",
- "time",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,16 +3258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,15 +3267,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -3645,28 +3301,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "typewit"
-version = "1.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -3681,10 +3319,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
@@ -3708,6 +3358,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "der",
+ "flate2",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3720,10 +3406,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "2.1.3"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3738,21 +3424,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
-dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3786,15 +3467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
-
-[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,21 +3485,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
-dependencies = [
- "wasi 0.14.7+wasi-0.2.4",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -3900,9 +3563,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.5.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3971,19 +3634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "whoami"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
-dependencies = [
- "libc",
- "libredox",
- "objc2-system-configuration",
- "wasite",
- "web-sys",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,27 +3665,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,17 +3675,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -4086,16 +3704,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core",
- "windows-link",
-]
 
 [[package]]
 name = "windows-registry"
@@ -4208,15 +3816,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -4469,151 +4068,6 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
-]
-
-[[package]]
-name = "xet-client"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45fc10a88b05d4824d7fc0f97d04c13eaea98da5e8032194b8a0cbdab942090"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64",
- "bytes",
- "crc32fast",
- "futures",
- "http 1.4.0",
- "hyper",
- "lazy_static",
- "more-asserts",
- "rand 0.10.1",
- "redb",
- "reqwest",
- "reqwest-middleware",
- "serde",
- "serde_json",
- "serde_repr",
- "statrs",
- "tempfile",
- "thiserror 2.0.19",
- "tokio",
- "tokio-retry",
- "tokio_with_wasm",
- "tracing",
- "url",
- "urlencoding",
- "web-time",
- "xet-core-structures",
- "xet-runtime",
-]
-
-[[package]]
-name = "xet-core-structures"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb39bc5e0478e8f03e15f08b0a396f197fcfa2ef5027da666fd100c806bf0ea3"
-dependencies = [
- "async-trait",
- "base64",
- "blake3",
- "bytemuck",
- "bytes",
- "countio",
- "futures",
- "futures-util",
- "getrandom 0.4.2",
- "heapify",
- "itertools 0.14.0",
- "lazy_static",
- "lz4_flex",
- "more-asserts",
- "rand 0.10.1",
- "regex",
- "safe-transmute",
- "serde",
- "static_assertions",
- "thiserror 2.0.19",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
- "web-time",
- "xet-runtime",
-]
-
-[[package]]
-name = "xet-data"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e428a3b9667c1d0d335a4c77407c04d3a3e6c4f228aee364a1b56ed94cf861ca"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "chrono",
- "gearhash",
- "http 1.4.0",
- "itertools 0.14.0",
- "lazy_static",
- "more-asserts",
- "rand 0.10.1",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tempfile",
- "thiserror 2.0.19",
- "tokio",
- "tokio-util",
- "tokio_with_wasm",
- "tracing",
- "url",
- "uuid",
- "web-time",
- "xet-client",
- "xet-core-structures",
- "xet-runtime",
-]
-
-[[package]]
-name = "xet-runtime"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e1f8cfa256029d1bba7860ca12bfd145f17aa7aede5d968e9c304047656be1"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "chrono",
- "colored",
- "const-str",
- "ctor",
- "dirs",
- "futures",
- "git-version",
- "humantime",
- "konst",
- "lazy_static",
- "libc",
- "more-asserts",
- "oneshot",
- "pin-project",
- "rand 0.10.1",
- "reqwest",
- "serde",
- "serde_json",
- "shellexpand",
- "sysinfo",
- "thiserror 2.0.19",
- "tokio",
- "tokio-util",
- "tokio_with_wasm",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "web-time",
- "whoami",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "2.0.18"
 tracing = "0.1"
 
 # examples and benchmarks
-hf-hub = { version = "1.0.0" }
+hf-hub = { version = "=0.5.0" }
 criterion = "0.8.2"
 pprof = "0.15.0"
 bindgen = "0.72.1"

--- a/examples/eagle/src/main.rs
+++ b/examples/eagle/src/main.rs
@@ -133,19 +133,19 @@ fn main() -> Result<()> {
     );
 
     let session_config = Eagle3SessionConfig::new(1, args.n_draft_max).with_p_min(args.p_min);
-    let mut session = match Eagle3Session::new_with_config(&target_ctx, &draft_ctx, session_config)
-    {
-        Ok(s) => s,
-        Err(e) => {
-            println!("\nEAGLE-3 session could not be created: {e}");
-            println!(
-                "(Is `{}` a valid EAGLE-3 draft model for this target? It must be",
-                args.draft.display()
-            );
-            println!(" converted with `convert_hf_to_gguf.py --target-model-dir <target>`.)");
-            return Ok(());
-        }
-    };
+    let mut session =
+        match Eagle3Session::new_with_config(&mut target_ctx, &mut draft_ctx, session_config) {
+            Ok(s) => s,
+            Err(e) => {
+                println!("\nEAGLE-3 session could not be created: {e}");
+                println!(
+                    "(Is `{}` a valid EAGLE-3 draft model for this target? It must be",
+                    args.draft.display()
+                );
+                println!(" converted with `convert_hf_to_gguf.py --target-model-dir <target>`.)");
+                return Ok(());
+            }
+        };
 
     println!(
         "EAGLE-3 session: n_draft_max={}, p_min={}, need_embd={}, need_embd_pre_norm={}",
@@ -163,21 +163,12 @@ fn main() -> Result<()> {
         return Ok(());
     };
 
-    run_speculative(
-        &target_model,
-        &mut target_ctx,
-        &mut draft_ctx,
-        &mut session,
-        &args.prompt,
-        n_predict,
-    )
+    run_speculative(&target_model, &mut session, &args.prompt, n_predict)
 }
 
 fn run_speculative(
     model: &LlamaModel,
-    target_ctx: &mut LlamaContext<'_>,
-    draft_ctx: &mut LlamaContext<'_>,
-    session: &mut Eagle3Session,
+    session: &mut Eagle3Session<'_, '_, '_>,
     prompt: &str,
     n_predict: i32,
 ) -> Result<()> {
@@ -189,25 +180,22 @@ fn run_speculative(
     }
 
     // Prompt prefill: decode the whole prompt as a single batch on the target.
-    let n_batch_max = target_ctx.n_batch() as usize;
+    let n_batch_max = session.target_context().n_batch() as usize;
     let prefill_capacity = tokens.len().max(n_batch_max);
     let mut batch = LlamaBatch::new(prefill_capacity, 1);
     let last_idx = tokens.len() - 1;
     for (i, tok) in tokens.iter().copied().enumerate() {
         batch.add(tok, i as i32, &[0], i == last_idx)?;
     }
-    target_ctx.decode(&mut batch).context("prefill failed")?;
-    // EAGLE-3 harvests the target's extracted hidden states from each decoded
-    // batch; hand every target decode to the session.
     session
-        .process(&batch)
-        .context("EAGLE-3 process(prefill) failed")?;
+        .decode_target_and_process(&mut batch)
+        .context("EAGLE-3 target prefill/process failed")?;
     session.begin(0, &tokens)?;
 
     // Greedy sampling keeps draft/verify token-exact so acceptance reflects the
     // draft quality rather than sampling noise.
     let mut sampler = LlamaSampler::chain_simple([LlamaSampler::greedy()]);
-    let mut last_token = sampler.sample(target_ctx, batch.n_tokens() - 1);
+    let mut last_token = sampler.sample(session.target_context(), batch.n_tokens() - 1);
     sampler.accept(last_token);
 
     let emit = |s: &str| {
@@ -245,17 +233,17 @@ fn run_speculative(
         }
         let n_verify = verify.n_tokens();
 
-        target_ctx
-            .decode(&mut verify)
-            .context("verify decode failed")?;
+        session
+            .decode_target(&mut verify)
+            .context("target verify decode failed")?;
 
         // draft() autoregressively advanced the draft context's KV at the
         // speculative positions (>= n_past). process(verify) re-decodes those
         // same positions with the target's harvested features, so roll the
         // draft KV back to n_past first to avoid a position collision
         // (mirrors the MTP example).
-        draft_ctx
-            .clear_kv_cache_seq(Some(0), Some(n_past as u32), None)
+        session
+            .clear_draft_kv_cache_seq(Some(0), Some(n_past as u32), None)
             .context("draft KV rollback before process failed")?;
 
         session
@@ -265,13 +253,13 @@ fn run_speculative(
         // Longest accepted prefix: sample the target at each output position and
         // compare against the corresponding draft. Output 0 predicts draft[0].
         let mut n_accepted: usize = 0;
-        let mut next_token = sampler.sample(target_ctx, 0);
+        let mut next_token = sampler.sample(session.target_context(), 0);
         sampler.accept(next_token);
         for (i, draft) in drafts.iter().enumerate() {
             if next_token == *draft {
                 n_accepted = i + 1;
                 if i + 1 < n_verify as usize {
-                    next_token = sampler.sample(target_ctx, (i + 1) as i32);
+                    next_token = sampler.sample(session.target_context(), (i + 1) as i32);
                     sampler.accept(next_token);
                 }
             } else {
@@ -285,8 +273,8 @@ fn run_speculative(
         // Trim the rejected suffix from both KV caches so the next round starts
         // from a consistent state.
         if (n_accepted as i32) < drafts.len() as i32 {
-            let ok = target_ctx
-                .clear_kv_cache_seq(Some(0), Some(new_n_past as u32), None)
+            let ok = session
+                .clear_target_kv_cache_seq(Some(0), Some(new_n_past as u32), None)
                 .context("target KV rollback errored")?;
             if !ok {
                 return Err(anyhow!(
@@ -294,7 +282,7 @@ fn run_speculative(
                      for recurrent/hybrid targets pass --n-rs-seq >= n-draft-max"
                 ));
             }
-            let _ = draft_ctx.clear_kv_cache_seq(Some(0), Some(new_n_past as u32), None);
+            let _ = session.clear_draft_kv_cache_seq(Some(0), Some(new_n_past as u32), None);
         }
 
         // Only report acceptance when a draft was actually produced. EAGLE-3

--- a/examples/mtp/src/main.rs
+++ b/examples/mtp/src/main.rs
@@ -163,7 +163,7 @@ fn main() -> Result<()> {
 
     let mut draft_ctx = draft_ctx;
     let session_config = MtpSessionConfig::new(1, args.n_draft_max).with_p_min(args.p_min);
-    let mut session = MtpSession::new_with_config(&target_ctx, &draft_ctx, session_config)?;
+    let mut session = MtpSession::new_with_config(&mut target_ctx, &mut draft_ctx, session_config)?;
     println!(
         "MTP session: n_draft_max={}, p_min={}, need_embd={}, need_embd_pre_norm={}",
         session.n_draft_max(),
@@ -178,21 +178,12 @@ fn main() -> Result<()> {
         return Ok(());
     };
 
-    run_speculative(
-        &model,
-        &mut target_ctx,
-        &mut draft_ctx,
-        &mut session,
-        &args.prompt,
-        n_predict,
-    )
+    run_speculative(&model, &mut session, &args.prompt, n_predict)
 }
 
 fn run_speculative(
     model: &LlamaModel,
-    target_ctx: &mut llama_cpp_4::context::LlamaContext<'_>,
-    draft_ctx: &mut llama_cpp_4::context::LlamaContext<'_>,
-    session: &mut MtpSession,
+    session: &mut MtpSession<'_, '_>,
     prompt: &str,
     n_predict: i32,
 ) -> Result<()> {
@@ -204,7 +195,7 @@ fn run_speculative(
     }
 
     // Prompt prefill: decode the whole prompt as a single batch.
-    let n_batch_max = target_ctx.n_batch() as usize;
+    let n_batch_max = session.target_context().n_batch() as usize;
     let prefill_capacity = tokens.len().max(n_batch_max);
     let mut batch = LlamaBatch::new(prefill_capacity, 1);
     // Session init configures pre-norm extraction on both contexts (upstream
@@ -215,15 +206,14 @@ fn run_speculative(
     for (i, tok) in tokens.iter().copied().enumerate() {
         batch.add(tok, i as i32, &[0], i == last_idx)?;
     }
-    target_ctx.decode(&mut batch).context("prefill failed")?;
     session
-        .process(&batch)
-        .context("MTP process(prefill) failed")?;
+        .decode_target_and_process(&mut batch)
+        .context("MTP target prefill/process failed")?;
     session.begin(0, &tokens)?;
 
     // Sample the first token from the prefill.
     let mut sampler = LlamaSampler::chain_simple([LlamaSampler::greedy()]);
-    let mut last_token = sampler.sample(target_ctx, batch.n_tokens() - 1);
+    let mut last_token = sampler.sample(session.target_context(), batch.n_tokens() - 1);
     sampler.accept(last_token);
 
     let mut output_text = String::new();
@@ -269,29 +259,26 @@ fn run_speculative(
         // positions on the draft side but with target's pre-norm h injected.
         // n_rs_seq on the draft context lets that recurrent-state rollback
         // succeed even though M-RoPE positions can't normally be re-written.
-        draft_ctx
-            .clear_kv_cache_seq(Some(0), Some(n_past as u32), None)
+        session
+            .clear_draft_kv_cache_seq(Some(0), Some(n_past as u32), None)
             .context("draft KV rollback failed")?;
 
-        target_ctx
-            .decode(&mut verify)
-            .context("verify decode failed")?;
         session
-            .process(&verify)
-            .context("MTP process(verify) failed")?;
+            .decode_target_and_process(&mut verify)
+            .context("MTP target verify/process failed")?;
 
         // Sample target at each output position and find the longest matching
         // prefix of the drafts. Output index 0 corresponds to the logits
         // following last_token (i.e. predicts draft[0]).
         let mut n_accepted: usize = 0;
-        let mut next_token = sampler.sample(target_ctx, 0);
+        let mut next_token = sampler.sample(session.target_context(), 0);
         sampler.accept(next_token);
 
         for (i, draft) in drafts.iter().enumerate() {
             if next_token == *draft {
                 n_accepted = i + 1;
                 if i + 1 < n_verify as usize {
-                    next_token = sampler.sample(target_ctx, (i + 1) as i32);
+                    next_token = sampler.sample(session.target_context(), (i + 1) as i32);
                     sampler.accept(next_token);
                 }
             } else {
@@ -311,8 +298,8 @@ fn run_speculative(
         // target and draft KVs both reach [0..n_past+drafts.len()]; keep only
         // up to position new_n_past - 1.
         if (n_accepted as i32) < drafts.len() as i32 {
-            let ok = target_ctx
-                .clear_kv_cache_seq(Some(0), Some(new_n_past as u32), None)
+            let ok = session
+                .clear_target_kv_cache_seq(Some(0), Some(new_n_past as u32), None)
                 .context("target KV rollback errored")?;
             if !ok {
                 return Err(anyhow!(
@@ -320,8 +307,8 @@ fn run_speculative(
                      ensure with_n_rs_seq(>0) is set on the target context"
                 ));
             }
-            let ok = draft_ctx
-                .clear_kv_cache_seq(Some(0), Some(new_n_past as u32), None)
+            let ok = session
+                .clear_draft_kv_cache_seq(Some(0), Some(new_n_past as u32), None)
                 .context("draft KV rollback errored")?;
             if !ok {
                 return Err(anyhow!(

--- a/llama-cpp-4/Cargo.toml
+++ b/llama-cpp-4/Cargo.toml
@@ -19,7 +19,7 @@ tracing = { workspace = true }
 encoding_rs = { workspace = true }
 
 [features]
-default = ["openmp", "mtmd"]
+default = ["openmp", "mtmd", "dynamic-link"]
 cuda = ["llama-cpp-sys-4/cuda"]
 metal = ["llama-cpp-sys-4/metal"]
 dynamic-link = ["llama-cpp-sys-4/dynamic-link"]

--- a/llama-cpp-4/Cargo.toml
+++ b/llama-cpp-4/Cargo.toml
@@ -19,7 +19,7 @@ tracing = { workspace = true }
 encoding_rs = { workspace = true }
 
 [features]
-default = ["openmp", "mtmd", "dynamic-link"]
+default = ["openmp", "mtmd"]
 cuda = ["llama-cpp-sys-4/cuda"]
 metal = ["llama-cpp-sys-4/metal"]
 dynamic-link = ["llama-cpp-sys-4/dynamic-link"]

--- a/llama-cpp-4/README.md
+++ b/llama-cpp-4/README.md
@@ -60,7 +60,7 @@ See [`prelude`](src/prelude.rs) on docs.rs for runnable examples (generation, ch
 |---|---|---|
 | `openmp` | ✅ | Multi-threaded CPU inference via OpenMP |
 | `mtmd` | ✅ | Multimodal (vision / audio) via `libmtmd` |
-| `dynamic-link` | ✅ | Link llama.cpp as a shared library |
+| `dynamic-link` | | Link llama.cpp as a shared library |
 | `cuda` | | NVIDIA GPU via CUDA |
 | `metal` | | Apple GPU via Metal |
 | `vulkan` | | Cross-platform GPU via Vulkan |

--- a/llama-cpp-4/README.md
+++ b/llama-cpp-4/README.md
@@ -227,29 +227,52 @@ for entry in ctx.memory_breakdown() {
 }
 ```
 
-### Tensor capture (hidden states)
+### Checked tensor capture (hidden states)
 
-Hook `cb_eval` during decode to copy per-layer outputs (`"l_out-N"`) or other
-named graph nodes:
+Attach owned, bounded exact selectors to copy per-layer outputs (`"l_out-N"`)
+or other named graph nodes during decode:
 
 ```rust
 use llama_cpp_4::prelude::*;
 
-let mut capture = TensorCapture::for_layers(&[13, 20, 27]);
-let ctx_params = LlamaContextParams::default().with_tensor_capture(&mut capture);
+let selector = TensorSelector::layer_output(
+    13,
+    model.n_embd() as usize,
+    512,
+    TensorAccess::ReadOnly,
+    true,
+)?;
+let transactions = TensorTransactions::capture(vec![selector])?;
+let ctx_params =
+    LlamaContextParams::default().with_tensor_transactions(transactions);
 let mut ctx = model.new_context(&backend, ctx_params)?;
 
 // ... fill batch, decode ...
 ctx.decode(&mut batch)?;
 
-if let Some(layer) = capture.get_layer(13) {
-    println!("{} tokens × {} dims", layer.n_tokens(), layer.n_embd());
-    let hidden = layer.token_embedding(0).unwrap();
+if let Some(layer) = ctx
+    .tensor_transactions()
+    .and_then(|transactions| transactions.captures().first())
+{
+    println!("{} rows × {} elements", layer.shape.rows, layer.shape.row_elements);
 }
 ```
 
 See also [`context::tensor_capture`](src/context/tensor_capture.rs) and
 `examples/eagle` (EAGLE-3 uses specific anchor layers).
+
+### Checked speculative sessions
+
+`MtpSession` and `Eagle3Session` exclusively borrow their target and draft
+contexts and are neither `Send` nor `Sync`. Construction validates context
+types, sequence capacity, recurrent-state capacity where required, hidden-row
+widths, and EAGLE-3 extraction-layer metadata before entering the native shim.
+Prompt copies, proposal bounds, and opaque continuation state are bounded.
+
+The shim contains C++ exceptions at every MTP/EAGLE-3 lifecycle entry point.
+Begin, process, draft, accept, and state failures return typed Rust errors
+instead of unwinding across the C ABI. Exact continuation state can be read or
+restored only after every proposal has been resolved.
 
 ### LoRA adapters
 

--- a/llama-cpp-4/README.md
+++ b/llama-cpp-4/README.md
@@ -60,7 +60,7 @@ See [`prelude`](src/prelude.rs) on docs.rs for runnable examples (generation, ch
 |---|---|---|
 | `openmp` | ✅ | Multi-threaded CPU inference via OpenMP |
 | `mtmd` | ✅ | Multimodal (vision / audio) via `libmtmd` |
-| `dynamic-link` | | Link llama.cpp as a shared library |
+| `dynamic-link` | ✅ | Link llama.cpp as a shared library |
 | `cuda` | | NVIDIA GPU via CUDA |
 | `metal` | | Apple GPU via Metal |
 | `vulkan` | | Cross-platform GPU via Vulkan |

--- a/llama-cpp-4/TENSOR_TRANSACTIONS_SAFETY.md
+++ b/llama-cpp-4/TENSOR_TRANSACTIONS_SAFETY.md
@@ -1,0 +1,76 @@
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# Tensor transaction safety contract
+
+`TensorTransactions` is the safe Rust boundary around llama.cpp's
+`ggml_backend_sched_eval_callback`. The implementation relies on the following
+contract.
+
+## Ownership and lifetime
+
+- `LlamaContextParams::with_tensor_transactions` moves the complete callback
+  state into a `Pin<Box<_>>` before installing its address in
+  `cb_eval_user_data`.
+- Creating a context moves that pinned box, without moving its allocation, into
+  `LlamaContext`.
+- `LlamaContext::drop` calls `llama_free` before Rust drops the pinned callback
+  state. No callback can therefore observe freed Rust state.
+- A transaction handler is owned by one context. Calls are synchronous and
+  serialized by the native context. Exact begin/end hooks cover both direct
+  `LlamaContext::decode` calls and llama.cpp decodes performed internally by a
+  speculative implementation.
+
+No Rust reference, slice, panic payload, or handler-owned pointer crosses the
+native boundary.
+
+## Native tensor access
+
+llama.cpp invokes the data phase only after computing and synchronizing the
+selected graph node. Before copying data, Rust verifies:
+
+- the exact graph-node name selected by the caller;
+- the exact `f32` or `i32` element type;
+- a two-dimensional, nonempty, contiguous layout;
+- the exact elements per row and an inclusive row bound;
+- the checked total element and byte counts; and
+- correspondence with the logical rows in the submitted decode batch.
+
+The callback copies the complete tensor into Rust-owned storage. A mutable
+`f32` transaction writes the complete owned copy back exactly once, only after
+the handler returns successfully and every output value is finite. Errors and
+unwinding cause no partial write-back.
+
+Retained captures are staged per native decode. They enter the committed
+capture set only after native success and complete selector-row coverage.
+Several internal decodes may commit into that set before Rust drains it; a
+failed decode discards only its staging area. Aggregate retained bytes remain
+bounded across the complete undrained set.
+
+## Failure containment
+
+The FFI callback catches all Rust unwinding and stores a bounded typed failure.
+After a data-phase failure it returns `true`: returning `false` there would
+cause llama.cpp's scheduler to stop executing the remainder of that graph
+split. Later ask phases return `false`, so native execution can finish without
+re-entering Rust for more selected data.
+
+`LlamaContext::decode` checks the stored failure after native execution returns
+and reports `DecodeError::TensorCallback`. The caller must conservatively treat
+that context as causally advanced; the binding does not roll back native
+context state.
+
+The first callback failure is sticky for the context lifetime. This prevents a
+later internal speculative decode from clearing evidence that an earlier
+callback failed before the outer Rust operation regained control.
+
+## Profile binding
+
+Graph-node names and layouts are implementation details of the pinned
+llama.cpp revision. A caller must bind its exact selectors to a separately
+validated model/backend profile. A selector mismatch fails closed after decode;
+there is no prefix matching, type coercion, shape inference, or silent
+fallback.
+
+The older `TensorCapture` callback remains available only through an `unsafe`
+constructor because it borrows external state without retaining a Rust
+lifetime. New code should use `TensorTransactions`.

--- a/llama-cpp-4/src/context.rs
+++ b/llama-cpp-4/src/context.rs
@@ -9,11 +9,12 @@
 
 use std::fmt::{Debug, Formatter};
 use std::num::NonZeroI32;
+use std::pin::Pin;
 use std::ptr::NonNull;
 use std::slice;
 
 use llama_cpp_sys_4::llama_pooling_type;
-use params::LlamaPoolingType;
+use params::{LlamaContextType, LlamaPoolingType};
 use perf::PerfContextData;
 
 use crate::llama_batch::LlamaBatch;
@@ -32,9 +33,16 @@ pub mod params;
 pub mod perf;
 pub mod session;
 pub mod tensor_capture;
+pub mod tensor_transaction;
 
 pub use memory_breakdown::MemoryBreakdownEntry;
 pub use tensor_capture::{CapturedTensor, TensorCapture};
+pub use tensor_transaction::{
+    CapturedTensorData, TensorAccess, TensorBatchRow, TensorCallbackFailure, TensorDataMut,
+    TensorElementType, TensorRowMapping, TensorSelector, TensorShape, TensorTransaction,
+    TensorTransactionError, TensorTransactionHandler, TensorTransactions, TensorWriteback,
+    TransactionalTensorCapture,
+};
 
 /// A safe wrapper around the `llama_context` C++ context.
 ///
@@ -63,6 +71,8 @@ pub struct LlamaContext<'a> {
     pub model: &'a LlamaModel,
     initialized_logits: Vec<i32>,
     embeddings_enabled: bool,
+    context_type: LlamaContextType,
+    tensor_transactions: Option<Pin<Box<TensorTransactions>>>,
 }
 
 impl Debug for LlamaContext<'_> {
@@ -86,6 +96,7 @@ impl<'model> LlamaContext<'model> {
     /// - `llama_context`: A non-null pointer to an existing `llama_cpp_sys_4::llama_context` representing
     ///   the context created in previous steps. This context is necessary for interacting with the model.
     /// - `embeddings_enabled`: A boolean flag indicating whether embeddings are enabled in this context.
+    /// - `context_type`: The exact graph/context mode selected at allocation.
     ///
     /// # Returns
     ///
@@ -98,20 +109,36 @@ impl<'model> LlamaContext<'model> {
     /// ```ignore
     /// let llama_model = LlamaModel::load_from_file(&backend, "path/to/model", &params).unwrap();
     /// let context_ptr = NonNull::new(some_llama_context_ptr).unwrap();
-    /// let context = LlamaContext::new(&llama_model, context_ptr, true);
+    /// let context = LlamaContext::new(
+    ///     &llama_model,
+    ///     context_ptr,
+    ///     true,
+    ///     LlamaContextType::Default,
+    ///     None,
+    /// );
     /// // Now you can use the context
     /// ```
     pub(crate) fn new(
         llama_model: &'model LlamaModel,
         llama_context: NonNull<llama_cpp_sys_4::llama_context>,
         embeddings_enabled: bool,
+        context_type: LlamaContextType,
+        tensor_transactions: Option<Pin<Box<TensorTransactions>>>,
     ) -> Self {
         Self {
             context: llama_context,
             model: llama_model,
             initialized_logits: Vec::new(),
             embeddings_enabled,
+            context_type,
+            tensor_transactions,
         }
+    }
+
+    /// Returns the context type selected at native allocation.
+    #[must_use]
+    pub fn context_type(&self) -> LlamaContextType {
+        self.context_type
     }
 
     /// Gets the max number of logical tokens that can be submitted to decode. Must be greater than or equal to `n_ubatch`.
@@ -144,6 +171,14 @@ impl<'model> LlamaContext<'model> {
     pub fn decode(&mut self, batch: &mut LlamaBatch) -> Result<(), DecodeError> {
         let result =
             unsafe { llama_cpp_sys_4::llama_decode(self.context.as_ptr(), batch.llama_batch) };
+        if let Some(failure) = self
+            .tensor_transactions
+            .as_ref()
+            .and_then(|transactions| transactions.failure())
+            .cloned()
+        {
+            return Err(DecodeError::TensorCallback(failure));
+        }
 
         match NonZeroI32::new(result) {
             None => {
@@ -153,6 +188,21 @@ impl<'model> LlamaContext<'model> {
             }
             Some(error) => Err(DecodeError::from(error)),
         }
+    }
+
+    /// Returns the owned tensor transaction program attached to this context.
+    #[must_use]
+    pub fn tensor_transactions(&self) -> Option<&TensorTransactions> {
+        self.tensor_transactions.as_deref()
+    }
+
+    /// Returns the owned tensor transaction program attached to this context.
+    ///
+    /// Retained captures can be removed with [`TensorTransactions::take_captures`].
+    pub fn tensor_transactions_mut(&mut self) -> Option<&mut TensorTransactions> {
+        self.tensor_transactions
+            .as_mut()
+            .map(|transactions| transactions.as_mut().get_mut())
     }
 
     /// Encodes the batch.

--- a/llama-cpp-4/src/context/params/mod.rs
+++ b/llama-cpp-4/src/context/params/mod.rs
@@ -9,9 +9,14 @@ mod types;
 pub use types::*;
 
 use std::num::NonZeroU32;
+use std::pin::Pin;
 
 use thiserror::Error;
 
+use super::tensor_transaction::{
+    tensor_transaction_callback, tensor_transaction_decode_begin, tensor_transaction_decode_end,
+    TensorTransactions,
+};
 use crate::sampling::LlamaSampler;
 
 /// Error returned when [`LlamaContextParams::try_clone`] cannot duplicate state.
@@ -20,6 +25,9 @@ pub enum ParamsCloneError {
     /// Per-sequence sampler chains cannot be duplicated.
     #[error("cannot clone params that own per-sequence sampler chains")]
     SamplerChains,
+    /// Owned tensor transaction handlers cannot be duplicated.
+    #[error("cannot clone params that own tensor transactions")]
+    TensorTransactions,
 }
 
 /// Builder for [`llama_context_params`](llama_cpp_sys_4::llama_context_params).
@@ -59,11 +67,8 @@ pub struct LlamaContextParams {
     /// Keeps sampler chains alive while `context_params.samplers` points at them.
     owned_samplers: Vec<LlamaSampler>,
     sampler_configs: Vec<llama_cpp_sys_4::llama_sampler_seq_config>,
+    pub(crate) tensor_transactions: Option<Pin<Box<TensorTransactions>>>,
 }
-
-/// SAFETY: we do not currently allow setting or reading the pointers that cause this to not be automatically send or sync.
-unsafe impl Send for LlamaContextParams {}
-unsafe impl Sync for LlamaContextParams {}
 
 impl LlamaContextParams {
     /// Set the side of the context
@@ -466,8 +471,17 @@ impl LlamaContextParams {
     /// named nodes, prefix, or all). After `decode()`, read results from the
     /// capture — see [`crate::TensorCapture`] and [`crate::context::tensor_capture`].
     ///
-    /// The capture must outlive the context. Call [`TensorCapture::clear`](crate::TensorCapture::clear) before
-    /// reusing it on another batch.
+    /// The capture must outlive the context. Call
+    /// [`TensorCapture::clear`](crate::TensorCapture::clear) before reusing it
+    /// on another batch. Prefer [`Self::with_tensor_transactions`], which
+    /// transfers owned pinned callback state into the context.
+    ///
+    /// # Safety
+    ///
+    /// The caller must keep `capture` at a stable address until after the
+    /// resulting context is dropped. It must not be accessed concurrently with
+    /// any context operation that can invoke the callback. The reference
+    /// accepted here does not remain borrowed by the returned params.
     ///
     /// # Example
     ///
@@ -484,17 +498,40 @@ impl LlamaContextParams {
     ///     .unwrap();
     ///
     ///     let mut capture = TensorCapture::for_layers(&[13, 20, 27]);
-    ///     let ctx_params = LlamaContextParams::default().with_tensor_capture(&mut capture);
+    ///     let ctx_params = unsafe {
+    ///         LlamaContextParams::default().with_tensor_capture(&mut capture)
+    ///     };
     ///     let _ctx = model.new_context(&backend, ctx_params).unwrap();
     /// }
     /// ```
     #[must_use]
-    pub fn with_tensor_capture(self, capture: &mut super::tensor_capture::TensorCapture) -> Self {
+    pub unsafe fn with_tensor_capture(
+        self,
+        capture: &mut super::tensor_capture::TensorCapture,
+    ) -> Self {
         self.with_cb_eval(Some(super::tensor_capture::tensor_capture_callback))
             .with_cb_eval_user_data(
                 std::ptr::from_mut::<super::tensor_capture::TensorCapture>(capture)
                     .cast::<std::ffi::c_void>(),
             )
+    }
+
+    /// Attaches bounded owned tensor transactions to the context.
+    ///
+    /// The transaction state is pinned before its address is installed in the
+    /// native callback parameters. On successful context creation ownership
+    /// moves into [`crate::LlamaContext`] and remains there until after
+    /// `llama_free`.
+    #[must_use]
+    pub fn with_tensor_transactions(mut self, transactions: TensorTransactions) -> Self {
+        let mut transactions = Box::pin(transactions);
+        let user_data = std::ptr::from_mut(transactions.as_mut().get_mut()).cast();
+        self.context_params.cb_eval = Some(tensor_transaction_callback);
+        self.context_params.cb_eval_user_data = user_data;
+        self.context_params.cb_decode_begin = Some(tensor_transaction_decode_begin);
+        self.context_params.cb_decode_end = Some(tensor_transaction_decode_end);
+        self.tensor_transactions = Some(transactions);
+        self
     }
 
     /// Set the storage type for the **K** (key) KV cache tensors.
@@ -620,13 +657,17 @@ impl LlamaContextParams {
     /// # Errors
     ///
     /// Returns [`ParamsCloneError::SamplerChains`] when per-sequence sampler
-    /// chains are attached and cannot be duplicated.
+    /// chains are attached and cannot be duplicated, or
+    /// [`ParamsCloneError::TensorTransactions`] when an owned callback program
+    /// is attached.
     pub fn try_clone(&self) -> Result<Self, ParamsCloneError> {
-        if self.sampler_configs.is_empty() {
-            Ok(self.clone())
-        } else {
-            Err(ParamsCloneError::SamplerChains)
+        if !self.sampler_configs.is_empty() {
+            return Err(ParamsCloneError::SamplerChains);
         }
+        if self.tensor_transactions.is_some() {
+            return Err(ParamsCloneError::TensorTransactions);
+        }
+        Ok(self.clone())
     }
 }
 
@@ -646,6 +687,7 @@ impl Default for LlamaContextParams {
             attn_rot_disabled: false,
             owned_samplers: Vec::new(),
             sampler_configs: Vec::new(),
+            tensor_transactions: None,
         }
     }
 }
@@ -661,11 +703,18 @@ impl Clone for LlamaContextParams {
         // Sampler chains cannot be duplicated here; cloned params omit them.
         context_params.samplers = std::ptr::null_mut();
         context_params.n_samplers = 0;
+        if self.tensor_transactions.is_some() {
+            context_params.cb_eval = None;
+            context_params.cb_eval_user_data = std::ptr::null_mut();
+            context_params.cb_decode_begin = None;
+            context_params.cb_decode_end = None;
+        }
         Self {
             context_params,
             attn_rot_disabled: self.attn_rot_disabled,
             owned_samplers: Vec::new(),
             sampler_configs: Vec::new(),
+            tensor_transactions: None,
         }
     }
 }

--- a/llama-cpp-4/src/context/tensor_capture.rs
+++ b/llama-cpp-4/src/context/tensor_capture.rs
@@ -25,8 +25,11 @@
 //!
 //! 1. Build a [`TensorCapture`] with the filter you need ([`TensorCapture::for_layers`]
 //!    is the common case).
-//! 2. Pass it to [`LlamaContextParams::with_tensor_capture`](crate::LlamaContextParams::with_tensor_capture). The capture must
-//!    **outlive** the [`LlamaContext`](crate::LlamaContext).
+//! 2. Pass it to the legacy unsafe
+//!    [`LlamaContextParams::with_tensor_capture`](crate::LlamaContextParams::with_tensor_capture).
+//!    The capture must remain at a stable address and outlive the
+//!    [`LlamaContext`](crate::LlamaContext). Prefer the owned, checked
+//!    [`TensorTransactions`](crate::TensorTransactions) API in new code.
 //! 3. Run [`LlamaContext::decode`](crate::LlamaContext::decode) as usual.
 //! 4. Read [`CapturedTensor`] values via [`TensorCapture::get_layer`],
 //!    [`TensorCapture::get`], or [`TensorCapture::iter`].
@@ -49,9 +52,11 @@
 //!     .unwrap();
 //!
 //!     let mut capture = TensorCapture::for_layers(&[13, 20, 27]);
-//!     let ctx_params = LlamaContextParams::default()
-//!         .with_n_ctx(NonZeroU32::new(512))
-//!         .with_tensor_capture(&mut capture);
+//!     let ctx_params = unsafe {
+//!         LlamaContextParams::default()
+//!             .with_n_ctx(NonZeroU32::new(512))
+//!             .with_tensor_capture(&mut capture)
+//!     };
 //!     let mut ctx = model.new_context(&backend, ctx_params).unwrap();
 //!
 //!     let tokens = model.str_to_token("Hello", AddBos::Always).unwrap();
@@ -149,15 +154,18 @@ enum CaptureFilter {
 
 /// Captures intermediate tensors during [`crate::LlamaContext::decode`].
 ///
-/// Attach with [`LlamaContextParams::with_tensor_capture`](crate::LlamaContextParams::with_tensor_capture) before creating the
-/// context. The same instance can be reused across decodes if you call
-/// [`Self::clear`] between passes.
+/// Attach with the legacy unsafe
+/// [`LlamaContextParams::with_tensor_capture`](crate::LlamaContextParams::with_tensor_capture)
+/// before creating the context. The same instance can be reused across decodes
+/// if you call [`Self::clear`] between passes.
 ///
 /// # Lifetime
 ///
-/// The capture must outlive the [`crate::LlamaContext`] it is wired into;
-/// [`LlamaContextParams::with_tensor_capture`](crate::LlamaContextParams::with_tensor_capture) takes `&mut TensorCapture` to
-/// enforce this at compile time.
+/// The capture must remain at a stable address and outlive the
+/// [`crate::LlamaContext`] it is wired into. This requirement is not enforced
+/// by the returned params; callers must uphold the unsafe constructor's
+/// contract. Prefer [`crate::TensorTransactions`], whose state is pinned and
+/// owned by the context.
 pub struct TensorCapture {
     filter: CaptureFilter,
     captured: HashMap<String, CapturedTensor>,

--- a/llama-cpp-4/src/context/tensor_transaction.rs
+++ b/llama-cpp-4/src/context/tensor_transaction.rs
@@ -1,0 +1,1166 @@
+//! Bounded, owned tensor capture and transactional mutation during decode.
+//!
+//! A [`TensorTransactions`] value is moved into
+//! [`LlamaContextParams::with_tensor_transactions`](crate::LlamaContextParams::with_tensor_transactions).
+//! The resulting [`crate::LlamaContext`] owns the callback state for its complete
+//! native lifetime. Matching tensors are synchronized by llama.cpp, copied into
+//! Rust-owned storage, and optionally transformed. Mutable tensors are written
+//! back exactly once only after the handler returns successfully and every
+//! output value passes validation.
+
+use std::collections::BTreeMap;
+use std::ffi::c_void;
+use std::fmt;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// Maximum exact graph selectors attached to one context.
+pub const MAX_TENSOR_SELECTORS: usize = 128;
+/// Maximum UTF-8 bytes in one exact graph-node name.
+pub const MAX_TENSOR_NAME_BYTES: usize = 256;
+/// Maximum rows accepted from one selected tensor invocation.
+pub const MAX_TENSOR_ROWS: usize = 4_096;
+/// Maximum elements copied by one selected tensor invocation.
+pub const MAX_TENSOR_ELEMENTS: usize = 16_777_216;
+/// Maximum retained tensor bytes from one decode.
+pub const MAX_RETAINED_TENSOR_BYTES: usize = MAX_TENSOR_ELEMENTS * size_of::<f32>();
+/// Maximum retained callback failure bytes.
+pub const MAX_TENSOR_FAILURE_BYTES: usize = 1_024;
+
+/// Element representation required by an exact tensor selector.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TensorElementType {
+    /// IEEE-754 single-precision values.
+    F32,
+    /// Signed 32-bit integer values.
+    I32,
+}
+
+impl TensorElementType {
+    const fn native(self) -> llama_cpp_sys_4::ggml_type {
+        match self {
+            Self::F32 => llama_cpp_sys_4::GGML_TYPE_F32,
+            Self::I32 => llama_cpp_sys_4::GGML_TYPE_I32,
+        }
+    }
+}
+
+/// Native access granted to one selected tensor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TensorAccess {
+    /// Copy and optionally retain the tensor without native mutation.
+    ReadOnly,
+    /// Run the handler over finite `f32` values and commit once on success.
+    ReadWriteF32,
+}
+
+/// Native write-back decision returned by a transaction handler.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TensorWriteback {
+    /// Discard handler-side edits and leave the native tensor unchanged.
+    Unchanged,
+    /// Validate and commit the complete edited tensor exactly once.
+    Commit,
+}
+
+/// Mapping between tensor rows and the submitted decode batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TensorRowMapping {
+    /// Rows correspond in order to logical token entries in the decode batch.
+    BatchTokens,
+}
+
+/// Exact bounded graph-node contract.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TensorSelector {
+    name: String,
+    element_type: TensorElementType,
+    row_elements: usize,
+    maximum_rows: usize,
+    access: TensorAccess,
+    row_mapping: TensorRowMapping,
+    retain: bool,
+}
+
+impl TensorSelector {
+    /// Constructs an exact tensor selector.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty, NUL-containing, or excessive name,
+    /// unusable dimensions, an excessive element bound, or mutable non-`f32`
+    /// data.
+    pub fn new(
+        name: impl Into<String>,
+        element_type: TensorElementType,
+        row_elements: usize,
+        maximum_rows: usize,
+        access: TensorAccess,
+        row_mapping: TensorRowMapping,
+        retain: bool,
+    ) -> Result<Self, TensorTransactionError> {
+        let selector = Self {
+            name: name.into(),
+            element_type,
+            row_elements,
+            maximum_rows,
+            access,
+            row_mapping,
+            retain,
+        };
+        selector.validate()?;
+        Ok(selector)
+    }
+
+    /// Constructs one exact residual layer-output selector.
+    ///
+    /// llama.cpp names these graph nodes `l_out-{layer}` at the pinned
+    /// implementation. The caller remains responsible for binding that naming
+    /// profile to its backend revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for unusable dimensions or bounds.
+    pub fn layer_output(
+        layer: u32,
+        row_elements: usize,
+        maximum_rows: usize,
+        access: TensorAccess,
+        retain: bool,
+    ) -> Result<Self, TensorTransactionError> {
+        Self::new(
+            format!("l_out-{layer}"),
+            TensorElementType::F32,
+            row_elements,
+            maximum_rows,
+            access,
+            TensorRowMapping::BatchTokens,
+            retain,
+        )
+    }
+
+    /// Returns the exact graph-node name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the required element representation.
+    #[must_use]
+    pub const fn element_type(&self) -> TensorElementType {
+        self.element_type
+    }
+
+    /// Returns the required elements per row.
+    #[must_use]
+    pub const fn row_elements(&self) -> usize {
+        self.row_elements
+    }
+
+    /// Returns the inclusive row bound.
+    #[must_use]
+    pub const fn maximum_rows(&self) -> usize {
+        self.maximum_rows
+    }
+
+    /// Returns native access granted to the handler.
+    #[must_use]
+    pub const fn access(&self) -> TensorAccess {
+        self.access
+    }
+
+    /// Returns how native rows map to the submitted decode batch.
+    #[must_use]
+    pub const fn row_mapping(&self) -> TensorRowMapping {
+        self.row_mapping
+    }
+
+    /// Returns whether the completed owned tensor is retained after decode.
+    #[must_use]
+    pub const fn retains_capture(&self) -> bool {
+        self.retain
+    }
+
+    fn validate(&self) -> Result<(), TensorTransactionError> {
+        if self.name.is_empty()
+            || self.name.len() > MAX_TENSOR_NAME_BYTES
+            || self.name.as_bytes().contains(&0)
+        {
+            return Err(TensorTransactionError::new(
+                "tensor name must be bounded, nonempty UTF-8 without NUL",
+            ));
+        }
+        let elements = self
+            .row_elements
+            .checked_mul(self.maximum_rows)
+            .ok_or_else(|| TensorTransactionError::new("tensor element bound overflowed"))?;
+        if self.row_elements == 0
+            || self.maximum_rows == 0
+            || self.maximum_rows > MAX_TENSOR_ROWS
+            || elements > MAX_TENSOR_ELEMENTS
+        {
+            return Err(TensorTransactionError::new(
+                "tensor row shape is outside the supported bound",
+            ));
+        }
+        if self.access == TensorAccess::ReadWriteF32 && self.element_type != TensorElementType::F32
+        {
+            return Err(TensorTransactionError::new(
+                "only f32 tensors support transactional write-back",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Exact sequence and causal-position metadata for one tensor row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TensorBatchRow {
+    /// Zero-based logical batch entry.
+    pub batch_index: u32,
+    /// Native causal position.
+    pub position: i32,
+    /// Exact sequence IDs attached to this entry.
+    pub sequence_ids: Vec<i32>,
+}
+
+/// Validated tensor dimensions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TensorShape {
+    /// Elements in each logical row.
+    pub row_elements: usize,
+    /// Logical rows in this callback invocation.
+    pub rows: usize,
+    /// Total elements.
+    pub elements: usize,
+}
+
+/// Typed Rust-owned tensor storage supplied to a callback.
+pub enum TensorDataMut<'a> {
+    /// Mutable finite `f32` storage.
+    F32(&'a mut [f32]),
+    /// Mutable copied `i32` storage. Read-only selectors never commit changes.
+    I32(&'a mut [i32]),
+}
+
+impl fmt::Debug for TensorDataMut<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::F32(values) => formatter
+                .debug_tuple("F32")
+                .field(&format_args!("{} elements", values.len()))
+                .finish(),
+            Self::I32(values) => formatter
+                .debug_tuple("I32")
+                .field(&format_args!("{} elements", values.len()))
+                .finish(),
+        }
+    }
+}
+
+/// One owned tensor transaction presented synchronously to Rust.
+pub struct TensorTransaction<'a> {
+    /// Exact graph-node name.
+    pub name: &'a str,
+    /// Validated shape.
+    pub shape: TensorShape,
+    /// Exact logical rows represented by this native tensor.
+    pub rows: &'a [TensorBatchRow],
+    /// Native access granted by the selector.
+    pub access: TensorAccess,
+    /// Typed Rust-owned values.
+    pub data: TensorDataMut<'a>,
+}
+
+impl fmt::Debug for TensorTransaction<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TensorTransaction")
+            .field("name", &self.name)
+            .field("shape", &self.shape)
+            .field("rows", &self.rows)
+            .field("access", &self.access)
+            .field("data", &self.data)
+            .finish()
+    }
+}
+
+/// Synchronous safe handler for selected tensor transactions.
+pub trait TensorTransactionHandler: Send {
+    /// Applies caller-defined mechanics to one Rust-owned tensor copy.
+    ///
+    /// For [`TensorAccess::ReadWriteF32`], successful finite output is written
+    /// back exactly once after this method returns. Returning an error or
+    /// unwinding causes no write-back.
+    ///
+    /// # Errors
+    ///
+    /// Returns an implementation-defined bounded failure.
+    fn apply(
+        &mut self,
+        transaction: TensorTransaction<'_>,
+    ) -> Result<TensorWriteback, TensorTransactionError>;
+}
+
+/// Error returned by a tensor transaction handler or selector validator.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("{message}")]
+pub struct TensorTransactionError {
+    message: String,
+}
+
+impl TensorTransactionError {
+    /// Creates a bounded transaction error.
+    pub fn new(message: impl Into<String>) -> Self {
+        let mut message = message.into();
+        if message.len() > MAX_TENSOR_FAILURE_BYTES {
+            message.truncate(MAX_TENSOR_FAILURE_BYTES);
+        }
+        Self { message }
+    }
+
+    /// Returns the bounded failure message.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+/// Contained callback failure returned by [`crate::LlamaContext::decode`].
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("tensor callback failed{tensor_suffix}: {message}")]
+pub struct TensorCallbackFailure {
+    tensor: Option<String>,
+    tensor_suffix: String,
+    panicked: bool,
+    message: String,
+}
+
+impl TensorCallbackFailure {
+    fn new(tensor: Option<&str>, panicked: bool, message: impl Into<String>) -> Self {
+        let mut message = message.into();
+        if message.len() > MAX_TENSOR_FAILURE_BYTES {
+            message.truncate(MAX_TENSOR_FAILURE_BYTES);
+        }
+        let tensor = tensor.map(ToOwned::to_owned);
+        let tensor_suffix = tensor
+            .as_deref()
+            .map_or_else(String::new, |name| format!(" for {name}"));
+        Self {
+            tensor,
+            tensor_suffix,
+            panicked,
+            message,
+        }
+    }
+
+    /// Returns the exact tensor name when failure happened after selection.
+    #[must_use]
+    pub fn tensor(&self) -> Option<&str> {
+        self.tensor.as_deref()
+    }
+
+    /// Returns whether Rust unwinding was contained.
+    #[must_use]
+    pub const fn panicked(&self) -> bool {
+        self.panicked
+    }
+
+    /// Returns the bounded failure message.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+/// Complete retained typed tensor from one callback invocation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransactionalTensorCapture {
+    /// Exact graph-node name.
+    pub name: String,
+    /// Validated shape.
+    pub shape: TensorShape,
+    /// Exact logical batch rows.
+    pub rows: Vec<TensorBatchRow>,
+    /// Typed copied values after a successful handler invocation.
+    pub data: CapturedTensorData,
+}
+
+/// Typed retained tensor storage.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CapturedTensorData {
+    /// Finite `f32` values.
+    F32(Vec<f32>),
+    /// Signed integer values.
+    I32(Vec<i32>),
+}
+
+impl CapturedTensorData {
+    /// Returns the retained element count.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::F32(values) => values.len(),
+            Self::I32(values) => values.len(),
+        }
+    }
+
+    /// Returns whether no elements are retained.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Owned, bounded callback program attached to one context.
+pub struct TensorTransactions {
+    selectors: Vec<TensorSelector>,
+    handler: Option<Box<dyn TensorTransactionHandler>>,
+    captures: Vec<TransactionalTensorCapture>,
+    retained_bytes: usize,
+    pending_captures: Vec<TransactionalTensorCapture>,
+    pending_retained_bytes: usize,
+    batch_rows: Vec<TensorBatchRow>,
+    rows_seen: BTreeMap<String, usize>,
+    failure: Option<TensorCallbackFailure>,
+    decode_active: bool,
+}
+
+impl fmt::Debug for TensorTransactions {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TensorTransactions")
+            .field("selectors", &self.selectors)
+            .field("has_handler", &self.handler.is_some())
+            .field("captures", &self.captures.len())
+            .field("retained_bytes", &self.retained_bytes)
+            .field("pending_captures", &self.pending_captures.len())
+            .field("pending_retained_bytes", &self.pending_retained_bytes)
+            .field("failure", &self.failure)
+            .field("decode_active", &self.decode_active)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TensorTransactions {
+    /// Constructs a read-only capture program.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for empty, excessive, duplicate, unordered, mutable,
+    /// or collectively over-bound selectors.
+    pub fn capture(selectors: Vec<TensorSelector>) -> Result<Self, TensorTransactionError> {
+        Self::build(selectors, None)
+    }
+
+    /// Constructs a capture/mutation program with one synchronous handler.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for empty, excessive, duplicate, unordered, or
+    /// collectively over-bound selectors.
+    pub fn new(
+        selectors: Vec<TensorSelector>,
+        handler: impl TensorTransactionHandler + 'static,
+    ) -> Result<Self, TensorTransactionError> {
+        Self::build(selectors, Some(Box::new(handler)))
+    }
+
+    fn build(
+        selectors: Vec<TensorSelector>,
+        handler: Option<Box<dyn TensorTransactionHandler>>,
+    ) -> Result<Self, TensorTransactionError> {
+        if selectors.is_empty() || selectors.len() > MAX_TENSOR_SELECTORS {
+            return Err(TensorTransactionError::new(
+                "selector count is outside the supported bound",
+            ));
+        }
+        let mut total_elements = 0_usize;
+        let mut prior_name: Option<&str> = None;
+        let mut needs_handler = false;
+        for selector in &selectors {
+            selector.validate()?;
+            if prior_name.is_some_and(|prior| prior >= selector.name()) {
+                return Err(TensorTransactionError::new(
+                    "selectors must have unique canonically ordered names",
+                ));
+            }
+            prior_name = Some(selector.name());
+            needs_handler |= selector.access == TensorAccess::ReadWriteF32;
+            total_elements = total_elements
+                .checked_add(
+                    selector
+                        .row_elements
+                        .checked_mul(selector.maximum_rows)
+                        .ok_or_else(|| {
+                            TensorTransactionError::new("selector element bound overflowed")
+                        })?,
+                )
+                .ok_or_else(|| {
+                    TensorTransactionError::new("total selector element bound overflowed")
+                })?;
+        }
+        if total_elements > MAX_TENSOR_ELEMENTS {
+            return Err(TensorTransactionError::new(
+                "total selector element bound is excessive",
+            ));
+        }
+        if needs_handler && handler.is_none() {
+            return Err(TensorTransactionError::new(
+                "mutable selectors require a transaction handler",
+            ));
+        }
+        if !needs_handler && handler.is_some() {
+            return Err(TensorTransactionError::new(
+                "a transaction handler requires at least one mutable selector",
+            ));
+        }
+        Ok(Self {
+            selectors,
+            handler,
+            captures: Vec::new(),
+            retained_bytes: 0,
+            pending_captures: Vec::new(),
+            pending_retained_bytes: 0,
+            batch_rows: Vec::new(),
+            rows_seen: BTreeMap::new(),
+            failure: None,
+            decode_active: false,
+        })
+    }
+
+    /// Returns exact selector contracts.
+    #[must_use]
+    pub fn selectors(&self) -> &[TensorSelector] {
+        &self.selectors
+    }
+
+    /// Returns successful retained tensors accumulated since the last drain.
+    ///
+    /// A native speculative operation may perform several internal decodes.
+    /// Each decode commits its retained tensors only after its lifecycle and
+    /// selector coverage complete successfully.
+    #[must_use]
+    pub fn captures(&self) -> &[TransactionalTensorCapture] {
+        &self.captures
+    }
+
+    /// Removes retained tensors accumulated since the previous drain.
+    pub fn take_captures(&mut self) -> Vec<TransactionalTensorCapture> {
+        self.retained_bytes = 0;
+        std::mem::take(&mut self.captures)
+    }
+
+    /// Returns the contained failure from the most recent decode.
+    #[must_use]
+    pub const fn failure(&self) -> Option<&TensorCallbackFailure> {
+        self.failure.as_ref()
+    }
+
+    fn begin_decode_raw(
+        &mut self,
+        batch: &llama_cpp_sys_4::llama_batch,
+    ) -> Result<(), TensorCallbackFailure> {
+        if let Some(failure) = self.failure.clone() {
+            return Err(failure);
+        }
+        if self.decode_active {
+            return Err(TensorCallbackFailure::new(
+                None,
+                false,
+                "tensor callback decode was already active",
+            ));
+        }
+        self.pending_captures.clear();
+        self.pending_retained_bytes = 0;
+        self.rows_seen.clear();
+        self.batch_rows = copy_batch_rows(batch)?;
+        self.decode_active = true;
+        Ok(())
+    }
+
+    pub(crate) fn finish_decode(
+        &mut self,
+        native_succeeded: bool,
+    ) -> Result<(), TensorCallbackFailure> {
+        self.decode_active = false;
+        let expected_rows = self.batch_rows.len();
+        self.batch_rows.clear();
+        if let Some(failure) = self.failure.clone() {
+            self.pending_captures.clear();
+            self.pending_retained_bytes = 0;
+            return Err(failure);
+        }
+        if !native_succeeded {
+            self.pending_captures.clear();
+            self.pending_retained_bytes = 0;
+            return Ok(());
+        }
+        for selector in &self.selectors {
+            let rows = self.rows_seen.get(selector.name()).copied().unwrap_or(0);
+            let complete = match selector.row_mapping {
+                TensorRowMapping::BatchTokens => rows == expected_rows,
+            };
+            if !complete {
+                let failure = TensorCallbackFailure::new(
+                    Some(selector.name()),
+                    false,
+                    format!(
+                        "selected tensor covered {rows} rows but the decode submitted \
+                         {expected_rows}"
+                    ),
+                );
+                self.failure = Some(failure.clone());
+                self.pending_captures.clear();
+                self.pending_retained_bytes = 0;
+                return Err(failure);
+            }
+        }
+        self.retained_bytes = self
+            .retained_bytes
+            .checked_add(self.pending_retained_bytes)
+            .ok_or_else(|| {
+                TensorCallbackFailure::new(None, false, "committed retained byte count overflowed")
+            })?;
+        self.captures.append(&mut self.pending_captures);
+        self.pending_retained_bytes = 0;
+        Ok(())
+    }
+
+    fn selected(&self, name: &str) -> Option<usize> {
+        self.selectors
+            .binary_search_by(|selector| selector.name().cmp(name))
+            .ok()
+    }
+
+    fn process(
+        &mut self,
+        tensor: *mut llama_cpp_sys_4::ggml_tensor,
+        selector_index: usize,
+    ) -> Result<(), TensorTransactionError> {
+        let selector = self.selectors[selector_index].clone();
+        let shape = validate_tensor(tensor, &selector)?;
+        let start = match selector.row_mapping {
+            TensorRowMapping::BatchTokens => {
+                self.rows_seen.get(selector.name()).copied().unwrap_or(0)
+            }
+        };
+        let end = start
+            .checked_add(shape.rows)
+            .ok_or_else(|| TensorTransactionError::new("tensor row mapping overflowed"))?;
+        if end > self.batch_rows.len() {
+            return Err(TensorTransactionError::new(
+                "tensor rows exceed submitted decode batch",
+            ));
+        }
+        let rows = self.batch_rows[start..end].to_vec();
+
+        match selector.element_type {
+            TensorElementType::F32 => {
+                let mut values = vec![0.0_f32; shape.elements];
+                copy_tensor_get(tensor, &mut values)?;
+                if values.iter().any(|value| !value.is_finite()) {
+                    return Err(TensorTransactionError::new(
+                        "selected f32 tensor contains a non-finite value",
+                    ));
+                }
+                if selector.access == TensorAccess::ReadWriteF32 {
+                    let original = selector.retain.then(|| values.clone());
+                    let handler = self.handler.as_deref_mut().ok_or_else(|| {
+                        TensorTransactionError::new("mutable tensor handler is unavailable")
+                    })?;
+                    let writeback = handler.apply(TensorTransaction {
+                        name: selector.name(),
+                        shape,
+                        rows: &rows,
+                        access: selector.access,
+                        data: TensorDataMut::F32(&mut values),
+                    })?;
+                    match writeback {
+                        TensorWriteback::Unchanged => {
+                            if let Some(original) = original {
+                                values = original;
+                            }
+                        }
+                        TensorWriteback::Commit => {
+                            if values.iter().any(|value| !value.is_finite()) {
+                                return Err(TensorTransactionError::new(
+                                    "transaction produced a non-finite f32 value",
+                                ));
+                            }
+                            copy_tensor_set(tensor, &values)?;
+                        }
+                    }
+                }
+                if selector.retain {
+                    self.retain(
+                        selector.name.clone(),
+                        shape,
+                        rows,
+                        CapturedTensorData::F32(values),
+                    )?;
+                }
+            }
+            TensorElementType::I32 => {
+                let mut values = vec![0_i32; shape.elements];
+                copy_tensor_get(tensor, &mut values)?;
+                if selector.retain {
+                    self.retain(
+                        selector.name.clone(),
+                        shape,
+                        rows,
+                        CapturedTensorData::I32(values),
+                    )?;
+                }
+            }
+        }
+        self.rows_seen.insert(selector.name, end);
+        Ok(())
+    }
+
+    fn retain(
+        &mut self,
+        name: String,
+        shape: TensorShape,
+        rows: Vec<TensorBatchRow>,
+        data: CapturedTensorData,
+    ) -> Result<(), TensorTransactionError> {
+        let bytes = data
+            .len()
+            .checked_mul(size_of::<f32>())
+            .ok_or_else(|| TensorTransactionError::new("retained byte count overflowed"))?;
+        self.pending_retained_bytes = self
+            .pending_retained_bytes
+            .checked_add(bytes)
+            .ok_or_else(|| TensorTransactionError::new("retained byte count overflowed"))?;
+        let total_retained_bytes = self
+            .retained_bytes
+            .checked_add(self.pending_retained_bytes)
+            .ok_or_else(|| TensorTransactionError::new("retained byte count overflowed"))?;
+        if total_retained_bytes > MAX_RETAINED_TENSOR_BYTES {
+            return Err(TensorTransactionError::new(
+                "retained tensor bytes exceed the supported bound",
+            ));
+        }
+        self.pending_captures.push(TransactionalTensorCapture {
+            name,
+            shape,
+            rows,
+            data,
+        });
+        Ok(())
+    }
+
+    fn record_failure(&mut self, tensor: Option<&str>, panicked: bool, message: impl Into<String>) {
+        if self.failure.is_none() {
+            self.failure = Some(TensorCallbackFailure::new(tensor, panicked, message));
+        }
+    }
+}
+
+fn validate_tensor(
+    tensor: *mut llama_cpp_sys_4::ggml_tensor,
+    selector: &TensorSelector,
+) -> Result<TensorShape, TensorTransactionError> {
+    if tensor.is_null() {
+        return Err(TensorTransactionError::new(
+            "native tensor pointer was null",
+        ));
+    }
+    // SAFETY: llama.cpp supplies a live graph tensor for the synchronous
+    // callback. No reference escapes this function.
+    let tensor_ref = unsafe { &*tensor };
+    if tensor_ref.type_ != selector.element_type.native() {
+        return Err(TensorTransactionError::new(
+            "native tensor element type does not match selector",
+        ));
+    }
+    if tensor_ref.ne[2] != 1 || tensor_ref.ne[3] != 1 {
+        return Err(TensorTransactionError::new(
+            "selected tensor must be a two-dimensional row matrix",
+        ));
+    }
+    let row_elements = usize::try_from(tensor_ref.ne[0])
+        .map_err(|_| TensorTransactionError::new("native row width is negative or excessive"))?;
+    let rows = usize::try_from(tensor_ref.ne[1])
+        .map_err(|_| TensorTransactionError::new("native row count is negative or excessive"))?;
+    let elements = row_elements
+        .checked_mul(rows)
+        .ok_or_else(|| TensorTransactionError::new("native tensor element count overflowed"))?;
+    if row_elements != selector.row_elements
+        || rows == 0
+        || rows > selector.maximum_rows
+        || elements > MAX_TENSOR_ELEMENTS
+    {
+        return Err(TensorTransactionError::new(
+            "native tensor shape does not match selector",
+        ));
+    }
+    // SAFETY: the pointer is live for this callback.
+    if !unsafe { llama_cpp_sys_4::ggml_is_contiguous(tensor) } {
+        return Err(TensorTransactionError::new(
+            "selected tensor is not contiguous",
+        ));
+    }
+    let expected_bytes = elements
+        .checked_mul(size_of::<f32>())
+        .ok_or_else(|| TensorTransactionError::new("native tensor byte count overflowed"))?;
+    // SAFETY: the pointer is live for this callback.
+    if unsafe { llama_cpp_sys_4::ggml_nbytes(tensor) } != expected_bytes {
+        return Err(TensorTransactionError::new(
+            "native tensor byte size does not match selector",
+        ));
+    }
+    Ok(TensorShape {
+        row_elements,
+        rows,
+        elements,
+    })
+}
+
+fn copy_tensor_get<T>(
+    tensor: *mut llama_cpp_sys_4::ggml_tensor,
+    values: &mut [T],
+) -> Result<(), TensorTransactionError> {
+    let bytes = size_of_val(values);
+    if bytes == 0 {
+        return Err(TensorTransactionError::new(
+            "cannot copy an empty native tensor",
+        ));
+    }
+    // SAFETY: `validate_tensor` proves the selected native tensor has exactly
+    // this contiguous byte size. `values` is live and exclusively borrowed.
+    unsafe {
+        llama_cpp_sys_4::ggml_backend_tensor_get(
+            tensor,
+            values.as_mut_ptr().cast::<c_void>(),
+            0,
+            bytes,
+        );
+    }
+    Ok(())
+}
+
+fn copy_tensor_set<T>(
+    tensor: *mut llama_cpp_sys_4::ggml_tensor,
+    values: &[T],
+) -> Result<(), TensorTransactionError> {
+    let bytes = size_of_val(values);
+    if bytes == 0 {
+        return Err(TensorTransactionError::new(
+            "cannot write an empty native tensor",
+        ));
+    }
+    // SAFETY: `validate_tensor` proves the selected native tensor has exactly
+    // this contiguous byte size. llama.cpp synchronized this node before the
+    // callback and later dependent nodes have not executed.
+    unsafe {
+        llama_cpp_sys_4::ggml_backend_tensor_set(
+            tensor,
+            values.as_ptr().cast::<c_void>(),
+            0,
+            bytes,
+        );
+    }
+    Ok(())
+}
+
+fn copy_batch_rows(
+    batch: &llama_cpp_sys_4::llama_batch,
+) -> Result<Vec<TensorBatchRow>, TensorCallbackFailure> {
+    let count = usize::try_from(batch.n_tokens).map_err(|_| {
+        TensorCallbackFailure::new(None, false, "decode batch token count is negative")
+    })?;
+    if count == 0 || count > MAX_TENSOR_ROWS {
+        return Err(TensorCallbackFailure::new(
+            None,
+            false,
+            "decode batch token count is outside the callback bound",
+        ));
+    }
+    if batch.pos.is_null() || batch.n_seq_id.is_null() || batch.seq_id.is_null() {
+        return Err(TensorCallbackFailure::new(
+            None,
+            false,
+            "decode batch metadata pointers are null",
+        ));
+    }
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..count {
+        // SAFETY: the native `llama_batch` contract provides arrays allocated
+        // for at least `n_tokens` entries, and the begin hook synchronously
+        // borrows the batch for this copy.
+        let position = unsafe { *batch.pos.add(index) };
+        // SAFETY: same allocation contract as `position`.
+        let sequence_count = unsafe { *batch.n_seq_id.add(index) };
+        let sequence_count = usize::try_from(sequence_count).map_err(|_| {
+            TensorCallbackFailure::new(None, false, "decode batch sequence count is negative")
+        })?;
+        if sequence_count == 0 || sequence_count > MAX_TENSOR_ROWS {
+            return Err(TensorCallbackFailure::new(
+                None,
+                false,
+                "decode batch sequence count is outside the callback bound",
+            ));
+        }
+        // SAFETY: the native `llama_batch` contract provides a sequence array
+        // with exactly `n_seq_id[index]` entries.
+        let sequence_ptr = unsafe { *batch.seq_id.add(index) };
+        if sequence_ptr.is_null() {
+            return Err(TensorCallbackFailure::new(
+                None,
+                false,
+                "decode batch sequence pointer is null",
+            ));
+        }
+        // SAFETY: validated count and live batch allocation above.
+        let sequence_ids =
+            unsafe { std::slice::from_raw_parts(sequence_ptr, sequence_count) }.to_vec();
+        rows.push(TensorBatchRow {
+            batch_index: u32::try_from(index)
+                .map_err(|_| TensorCallbackFailure::new(None, false, "batch index exceeds u32"))?,
+            position,
+            sequence_ids,
+        });
+    }
+    Ok(rows)
+}
+
+pub(crate) unsafe extern "C" fn tensor_transaction_decode_begin(
+    batch: *const llama_cpp_sys_4::llama_batch,
+    user_data: *mut c_void,
+) -> bool {
+    if batch.is_null() || user_data.is_null() {
+        return false;
+    }
+    // SAFETY: context parameters retain the pinned transaction owner for every
+    // native decode and llama.cpp supplies a live batch for this call.
+    let state = unsafe { &mut *user_data.cast::<TensorTransactions>() };
+    // SAFETY: null was rejected and the batch remains live synchronously.
+    let batch = unsafe { &*batch };
+    let result = catch_unwind(AssertUnwindSafe(|| state.begin_decode_raw(batch)));
+    match result {
+        Ok(Ok(())) => true,
+        Ok(Err(error)) => {
+            state.record_failure(None, false, error.to_string());
+            false
+        }
+        Err(_) => {
+            state.record_failure(None, true, "tensor decode-begin callback panicked");
+            false
+        }
+    }
+}
+
+pub(crate) unsafe extern "C" fn tensor_transaction_decode_end(
+    native_succeeded: bool,
+    user_data: *mut c_void,
+) -> bool {
+    if user_data.is_null() {
+        return false;
+    }
+    // SAFETY: context parameters retain the pinned transaction owner for every
+    // native decode.
+    let state = unsafe { &mut *user_data.cast::<TensorTransactions>() };
+    let result = catch_unwind(AssertUnwindSafe(|| state.finish_decode(native_succeeded)));
+    match result {
+        Ok(Ok(())) => true,
+        Ok(Err(error)) => {
+            state.record_failure(error.tensor(), error.panicked(), error.message());
+            false
+        }
+        Err(_) => {
+            state.record_failure(None, true, "tensor decode-end callback panicked");
+            false
+        }
+    }
+}
+
+pub(crate) unsafe extern "C" fn tensor_transaction_callback(
+    tensor: *mut llama_cpp_sys_4::ggml_tensor,
+    ask: bool,
+    user_data: *mut c_void,
+) -> bool {
+    if tensor.is_null() || user_data.is_null() {
+        return false;
+    }
+    // SAFETY: `LlamaContextParams::with_tensor_transactions` installs a pointer
+    // to pinned state owned by the context for the complete native lifetime.
+    let state = unsafe { &mut *user_data.cast::<TensorTransactions>() };
+    if !state.decode_active {
+        state.record_failure(
+            None,
+            false,
+            "tensor evaluation callback ran outside a decode lifecycle",
+        );
+        return false;
+    }
+    if state.failure.is_some() {
+        // Do not request more callbacks, allowing the scheduler to finish the
+        // remaining graph without another Rust boundary.
+        return false;
+    }
+    // SAFETY: graph tensor names are fixed NUL-terminated arrays.
+    let name_bytes = unsafe { &(*tensor).name };
+    let length = name_bytes
+        .iter()
+        .position(|value| *value == 0)
+        .unwrap_or(name_bytes.len());
+    let raw_name =
+        // SAFETY: `c_char` and `u8` have identical byte width.
+        unsafe { std::slice::from_raw_parts(name_bytes.as_ptr().cast::<u8>(), length) };
+    let name = match std::str::from_utf8(raw_name) {
+        Ok(name) => name,
+        Err(error) => {
+            state.record_failure(None, false, format!("tensor name is not UTF-8: {error}"));
+            return false;
+        }
+    };
+    let Some(selector_index) = state.selected(name) else {
+        return false;
+    };
+    if ask {
+        return true;
+    }
+
+    let result = catch_unwind(AssertUnwindSafe(|| state.process(tensor, selector_index)));
+    match result {
+        Ok(Ok(())) => true,
+        Ok(Err(error)) => {
+            state.record_failure(Some(name), false, error.to_string());
+            true
+        }
+        Err(payload) => {
+            let message = payload
+                .downcast_ref::<&str>()
+                .map_or_else(
+                    || {
+                        payload
+                            .downcast_ref::<String>()
+                            .map_or("tensor handler panicked", String::as_str)
+                    },
+                    |message| *message,
+                )
+                .to_owned();
+            state.record_failure(Some(name), true, message);
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct AddOne;
+
+    impl TensorTransactionHandler for AddOne {
+        fn apply(
+            &mut self,
+            mut transaction: TensorTransaction<'_>,
+        ) -> Result<TensorWriteback, TensorTransactionError> {
+            let TensorDataMut::F32(values) = &mut transaction.data else {
+                return Err(TensorTransactionError::new("expected f32"));
+            };
+            for value in values.iter_mut() {
+                *value += 1.0;
+            }
+            Ok(TensorWriteback::Commit)
+        }
+    }
+
+    #[test]
+    fn selectors_are_bounded_and_canonical() {
+        let selector = TensorSelector::layer_output(1, 4, 2, TensorAccess::ReadOnly, true).unwrap();
+        assert_eq!(selector.name(), "l_out-1");
+        assert!(TensorSelector::new(
+            "bad\0name",
+            TensorElementType::F32,
+            4,
+            2,
+            TensorAccess::ReadOnly,
+            TensorRowMapping::BatchTokens,
+            true,
+        )
+        .is_err());
+        assert!(TensorSelector::new(
+            "integer",
+            TensorElementType::I32,
+            4,
+            2,
+            TensorAccess::ReadWriteF32,
+            TensorRowMapping::BatchTokens,
+            true,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn transaction_sets_require_a_handler_and_ordered_names() {
+        let mutable =
+            TensorSelector::layer_output(1, 4, 2, TensorAccess::ReadWriteF32, false).unwrap();
+        assert!(TensorTransactions::capture(vec![mutable.clone()]).is_err());
+        assert!(TensorTransactions::new(vec![mutable], AddOne).is_ok());
+
+        let later = TensorSelector::layer_output(2, 4, 2, TensorAccess::ReadOnly, true).unwrap();
+        let earlier = TensorSelector::layer_output(1, 4, 2, TensorAccess::ReadOnly, true).unwrap();
+        assert!(TensorTransactions::capture(vec![later, earlier]).is_err());
+    }
+
+    #[test]
+    fn errors_and_failure_messages_are_bounded() {
+        let error = TensorTransactionError::new("x".repeat(MAX_TENSOR_FAILURE_BYTES + 10));
+        assert_eq!(error.message().len(), MAX_TENSOR_FAILURE_BYTES);
+        let failure = TensorCallbackFailure::new(
+            Some("l_out-1"),
+            true,
+            "y".repeat(MAX_TENSOR_FAILURE_BYTES + 10),
+        );
+        assert!(failure.panicked());
+        assert_eq!(failure.message().len(), MAX_TENSOR_FAILURE_BYTES);
+        assert_eq!(failure.tensor(), Some("l_out-1"));
+    }
+
+    #[test]
+    fn successful_internal_decodes_accumulate_and_failed_staging_is_discarded() {
+        let selector = TensorSelector::layer_output(1, 1, 1, TensorAccess::ReadOnly, true).unwrap();
+        let mut transactions = TensorTransactions::capture(vec![selector]).unwrap();
+
+        let stage = |transactions: &mut TensorTransactions, value: f32, succeeded: bool| {
+            transactions.decode_active = true;
+            transactions.batch_rows = vec![TensorBatchRow {
+                batch_index: 0,
+                position: 0,
+                sequence_ids: vec![0],
+            }];
+            transactions.rows_seen.insert("l_out-1".to_owned(), 1);
+            transactions
+                .retain(
+                    "l_out-1".to_owned(),
+                    TensorShape {
+                        row_elements: 1,
+                        rows: 1,
+                        elements: 1,
+                    },
+                    transactions.batch_rows.clone(),
+                    CapturedTensorData::F32(vec![value]),
+                )
+                .unwrap();
+            transactions.finish_decode(succeeded).unwrap();
+        };
+
+        stage(&mut transactions, 1.0, true);
+        stage(&mut transactions, 2.0, true);
+        stage(&mut transactions, 3.0, false);
+        let captures = transactions.take_captures();
+        assert_eq!(captures.len(), 2);
+        assert!(matches!(
+            captures[0].data,
+            CapturedTensorData::F32(ref values) if values == &[1.0]
+        ));
+        assert!(matches!(
+            captures[1].data,
+            CapturedTensorData::F32(ref values) if values == &[2.0]
+        ));
+        assert!(transactions.captures().is_empty());
+    }
+}

--- a/llama-cpp-4/src/eagle.rs
+++ b/llama-cpp-4/src/eagle.rs
@@ -29,13 +29,13 @@
 //! let n_draft_max = 3;
 //!
 //! // Target: the main model, a normal (default) context.
-//! let target = main_model.new_context(&backend, LlamaContextParams::default())?;
+//! let mut target = main_model.new_context(&backend, LlamaContextParams::default())?;
 //!
 //! // Draft: a SEPARATE EAGLE-3 draft model, also a default context.
-//! let draft = eagle3_model.new_context(&backend, LlamaContextParams::default())?;
+//! let mut draft = eagle3_model.new_context(&backend, LlamaContextParams::default())?;
 //!
 //! let config = Eagle3SessionConfig::new(1, n_draft_max);
-//! let mut session = Eagle3Session::new_with_config(&target, &draft, config)?;
+//! let mut session = Eagle3Session::new_with_config(&mut target, &mut draft, config)?;
 //! ```
 //!
 //! # Speculative loop
@@ -46,8 +46,7 @@
 //! were accepted with [`accept`](Eagle3Session::accept).
 //!
 //! ```ignore
-//! target.decode(&mut batch)?;
-//! session.process(&batch)?;
+//! session.decode_target_and_process(&mut batch)?;
 //! let drafts = session.draft(0, n_past, last_token)?;
 //! // verify `drafts` against the target, count acceptances ...
 //! session.accept(0, n_accepted)?;
@@ -61,10 +60,15 @@
 //! [`need_embd_pre_norm`](Eagle3Session::need_embd_pre_norm) report which kind
 //! the active backend requested (rarely needed by callers).
 
+use std::marker::PhantomData;
 use std::ptr::NonNull;
+use std::rc::Rc;
 
+use crate::context::params::LlamaContextType;
 use crate::context::LlamaContext;
 use crate::llama_batch::LlamaBatch;
+use crate::speculative::MAX_SPECULATIVE_PROMPT_TOKENS;
+use crate::speculative::{capture_state, restore_state, validate_config, SpeculativeStateError};
 use crate::token::LlamaToken;
 
 /// Errors raised by the EAGLE-3 draft session.
@@ -81,6 +85,31 @@ pub enum Eagle3SessionError {
     #[error("EAGLE-3 process failed (see llama.cpp logs)")]
     Process,
 
+    /// Native prompt initialization failed or raised a contained exception.
+    #[error("EAGLE-3 begin failed")]
+    Begin,
+
+    /// Native draft generation failed or raised a contained exception.
+    #[error("EAGLE-3 draft failed")]
+    Draft,
+
+    /// Native proposal acceptance failed or raised a contained exception.
+    #[error("EAGLE-3 accept failed")]
+    Accept,
+
+    /// Prompt storage exceeds the safe speculative-session bound.
+    #[error("prompt has {size} tokens, exceeding the {maximum}-token bound")]
+    PromptTooLong {
+        /// Caller-supplied prompt-token count.
+        size: usize,
+        /// Inclusive safe prompt-token bound.
+        maximum: usize,
+    },
+
+    /// The supplied contexts do not satisfy the native EAGLE-3 contract.
+    #[error("incompatible EAGLE-3 contexts: {0}")]
+    IncompatibleContexts(&'static str),
+
     /// Caller passed a sequence id outside `[0, n_seq)`.
     #[error("sequence id {seq_id} out of range (n_seq = {n_seq})")]
     BadSeqId {
@@ -93,6 +122,37 @@ pub enum Eagle3SessionError {
     /// Invalid session configuration (e.g. `n_draft_max <= 0`).
     #[error("invalid EAGLE-3 session config: {0}")]
     InvalidConfig(&'static str),
+
+    /// The target context failed to decode.
+    #[error("target decode failed: {0}")]
+    Decode(#[from] crate::DecodeError),
+
+    /// An operation requires all draft proposals to be completed first.
+    #[error("sequence {seq_id} still has an unaccepted draft proposal")]
+    ProposalPending {
+        /// Sequence with a pending proposal.
+        seq_id: i32,
+    },
+
+    /// `accept` was called without a preceding nonempty draft.
+    #[error("sequence {seq_id} has no draft proposal to accept")]
+    NoPendingProposal {
+        /// Sequence without a pending proposal.
+        seq_id: i32,
+    },
+
+    /// The accepted prefix exceeds the proposal length.
+    #[error("accepted {accepted} tokens from a {proposed}-token proposal")]
+    AcceptedTooMany {
+        /// Accepted prefix length.
+        accepted: u16,
+        /// Exact proposal length.
+        proposed: usize,
+    },
+
+    /// Exact speculative-state capture or restore failed.
+    #[error(transparent)]
+    State(#[from] SpeculativeStateError),
 }
 
 /// Parameters for [`Eagle3Session::new_with_config`].
@@ -144,21 +204,19 @@ impl Eagle3SessionConfig {
 ///
 /// Drops the underlying speculative context when freed.
 ///
-/// # Lifetime contract (manual)
-///
-/// The session holds raw pointers to both the target and draft
-/// [`LlamaContext`]s. **The caller must keep both contexts alive (i.e. not
-/// drop them) for as long as the session exists.**
-pub struct Eagle3Session {
+/// Both contexts are exclusively borrowed for the session lifetime. The
+/// wrapper retains no manually enforced lifetime and is neither `Send` nor
+/// `Sync`.
+pub struct Eagle3Session<'ctx, 'target_model, 'draft_model> {
     raw: NonNull<llama_cpp_sys_4::mtp_session>,
     config: Eagle3SessionConfig,
+    target: &'ctx mut LlamaContext<'target_model>,
+    draft: &'ctx mut LlamaContext<'draft_model>,
+    pending_proposals: Vec<Option<usize>>,
+    not_send_sync: PhantomData<Rc<()>>,
 }
 
-// SAFETY: the underlying C++ session owns its own state and is not tied to any
-// TLS. Concurrent calls from multiple threads are NOT safe.
-unsafe impl Send for Eagle3Session {}
-
-impl Eagle3Session {
+impl<'ctx, 'target_model, 'draft_model> Eagle3Session<'ctx, 'target_model, 'draft_model> {
     /// Construct an EAGLE-3 draft session with upstream defaults for `n_min`
     /// and `p_min`.
     ///
@@ -168,8 +226,8 @@ impl Eagle3Session {
     ///
     /// Returns [`Eagle3SessionError::Init`] or [`Eagle3SessionError::InvalidConfig`].
     pub fn new(
-        target: &LlamaContext<'_>,
-        draft: &LlamaContext<'_>,
+        target: &'ctx mut LlamaContext<'target_model>,
+        draft: &'ctx mut LlamaContext<'draft_model>,
         n_seq: u32,
         n_draft_max: i32,
     ) -> Result<Self, Eagle3SessionError> {
@@ -189,16 +247,15 @@ impl Eagle3Session {
     /// Returns [`Eagle3SessionError::Init`] (e.g. the draft model is not a
     /// valid EAGLE-3 model) or [`Eagle3SessionError::InvalidConfig`].
     pub fn new_with_config(
-        target: &LlamaContext<'_>,
-        draft: &LlamaContext<'_>,
+        target: &'ctx mut LlamaContext<'target_model>,
+        draft: &'ctx mut LlamaContext<'draft_model>,
         config: Eagle3SessionConfig,
     ) -> Result<Self, Eagle3SessionError> {
-        if config.n_seq == 0 {
-            return Err(Eagle3SessionError::InvalidConfig("n_seq must be > 0"));
-        }
-        if config.n_draft_max <= 0 {
-            return Err(Eagle3SessionError::InvalidConfig("n_draft_max must be > 0"));
-        }
+        validate_config(config.n_seq, config.n_draft_max, config.n_min, config.p_min)
+            .map_err(Eagle3SessionError::InvalidConfig)?;
+        validate_contexts(target, draft, config)?;
+        let sequence_slots = usize::try_from(config.n_seq)
+            .map_err(|_| Eagle3SessionError::InvalidConfig("n_seq exceeds usize"))?;
 
         // `MTP_SPEC_TYPE_*` is `c_uint` under clang/gcc and `c_int` under MSVC;
         // `as i32` compiles on both. The allow covers the clang/gcc case.
@@ -219,7 +276,14 @@ impl Eagle3Session {
             )
         };
         let raw = NonNull::new(raw).ok_or(Eagle3SessionError::Init)?;
-        Ok(Self { raw, config })
+        Ok(Self {
+            raw,
+            config,
+            target,
+            draft,
+            pending_proposals: vec![None; sequence_slots],
+            not_send_sync: PhantomData,
+        })
     }
 
     /// Session configuration passed at construction.
@@ -269,6 +333,63 @@ impl Eagle3Session {
         self.config.n_seq
     }
 
+    /// Returns shared access to the target context for reading logits,
+    /// embeddings, and model metadata.
+    #[must_use]
+    pub fn target_context(&self) -> &LlamaContext<'target_model> {
+        self.target
+    }
+
+    /// Returns exclusive access to the target context while this wrapper
+    /// retains native pointer ownership.
+    #[must_use]
+    pub fn target_context_mut(&mut self) -> &mut LlamaContext<'target_model> {
+        self.target
+    }
+
+    /// Returns shared access to the draft context for metadata inspection.
+    #[must_use]
+    pub fn draft_context(&self) -> &LlamaContext<'draft_model> {
+        self.draft
+    }
+
+    /// Returns exclusive access to the draft context while this wrapper
+    /// retains native pointer ownership.
+    #[must_use]
+    pub fn draft_context_mut(&mut self) -> &mut LlamaContext<'draft_model> {
+        self.draft
+    }
+
+    /// Decodes on the target and immediately harvests the same batch into
+    /// EAGLE-3.
+    ///
+    /// # Errors
+    ///
+    /// Returns a target [`crate::DecodeError`] or native process failure.
+    pub fn decode_target_and_process(
+        &mut self,
+        batch: &mut LlamaBatch,
+    ) -> Result<(), Eagle3SessionError> {
+        self.decode_target(batch)?;
+        self.process(batch)
+    }
+
+    /// Decodes one batch on the exclusively held target context.
+    ///
+    /// Use [`Self::decode_target_and_process`] unless mechanics must run
+    /// between target decode and draft-state harvesting. This method remains
+    /// available while a draft proposal is pending because that is the target
+    /// verification phase; proposal creation, begin, and state access retain
+    /// their stricter lifecycle checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns a target [`crate::DecodeError`].
+    pub fn decode_target(&mut self, batch: &mut LlamaBatch) -> Result<(), Eagle3SessionError> {
+        self.target.decode(batch)?;
+        Ok(())
+    }
+
     /// Log speculative-decoding statistics (draft/accept counts and timings)
     /// via llama.cpp `LOG_INF`. Install a log callback with [`crate::log_set`]
     /// to capture output.
@@ -284,13 +405,23 @@ impl Eagle3Session {
     /// Returns [`Eagle3SessionError::BadSeqId`] if `seq_id` is out of range.
     pub fn begin(&mut self, seq_id: i32, prompt: &[LlamaToken]) -> Result<(), Eagle3SessionError> {
         self.check_seq(seq_id)?;
-        unsafe {
+        self.require_quiescent()?;
+        if prompt.len() > MAX_SPECULATIVE_PROMPT_TOKENS {
+            return Err(Eagle3SessionError::PromptTooLong {
+                size: prompt.len(),
+                maximum: MAX_SPECULATIVE_PROMPT_TOKENS,
+            });
+        }
+        let ok = unsafe {
             llama_cpp_sys_4::mtp_session_begin(
                 self.raw.as_ptr(),
                 seq_id,
                 prompt.as_ptr().cast(),
                 prompt.len(),
-            );
+            )
+        };
+        if !ok {
+            return Err(Eagle3SessionError::Begin);
         }
         Ok(())
     }
@@ -330,12 +461,16 @@ impl Eagle3Session {
         id_last: LlamaToken,
     ) -> Result<Vec<LlamaToken>, Eagle3SessionError> {
         self.check_seq(seq_id)?;
+        let sequence_index = self.sequence_index(seq_id)?;
+        if self.pending_proposals[sequence_index].is_some() {
+            return Err(Eagle3SessionError::ProposalPending { seq_id });
+        }
 
         let cap = usize::try_from(self.config.n_draft_max.max(0)).unwrap_or(0);
         let mut buf: Vec<i32> = vec![0; cap];
         let mut out_n = i32::try_from(cap).unwrap_or(i32::MAX);
 
-        unsafe {
+        let ok = unsafe {
             llama_cpp_sys_4::mtp_session_draft(
                 self.raw.as_ptr(),
                 seq_id,
@@ -343,11 +478,17 @@ impl Eagle3Session {
                 id_last.0,
                 buf.as_mut_ptr(),
                 &raw mut out_n,
-            );
+            )
+        };
+        if !ok {
+            return Err(Eagle3SessionError::Draft);
         }
 
         let n = usize::try_from(out_n.max(0)).unwrap_or(0);
         buf.truncate(n);
+        if n > 0 {
+            self.pending_proposals[sequence_index] = Some(n);
+        }
         Ok(buf.into_iter().map(LlamaToken).collect())
     }
 
@@ -360,8 +501,151 @@ impl Eagle3Session {
     /// Returns [`Eagle3SessionError::BadSeqId`] if `seq_id` is out of range.
     pub fn accept(&mut self, seq_id: i32, n_accepted: u16) -> Result<(), Eagle3SessionError> {
         self.check_seq(seq_id)?;
-        unsafe {
-            llama_cpp_sys_4::mtp_session_accept(self.raw.as_ptr(), seq_id, n_accepted);
+        let sequence_index = self.sequence_index(seq_id)?;
+        let proposed = self.pending_proposals[sequence_index]
+            .ok_or(Eagle3SessionError::NoPendingProposal { seq_id })?;
+        if usize::from(n_accepted) > proposed {
+            return Err(Eagle3SessionError::AcceptedTooMany {
+                accepted: n_accepted,
+                proposed,
+            });
+        }
+        let ok =
+            unsafe { llama_cpp_sys_4::mtp_session_accept(self.raw.as_ptr(), seq_id, n_accepted) };
+        if !ok {
+            return Err(Eagle3SessionError::Accept);
+        }
+        self.pending_proposals[sequence_index] = None;
+        Ok(())
+    }
+
+    /// Returns `true` when every draft proposal has been completed.
+    #[must_use]
+    pub fn is_quiescent(&self) -> bool {
+        self.pending_proposals.iter().all(Option::is_none)
+            && unsafe { llama_cpp_sys_4::mtp_session_is_quiescent(self.raw.as_ptr()) }
+    }
+
+    /// Captures versioned per-sequence speculative continuation state.
+    ///
+    /// Target and draft context bytes are separate and must be checkpointed at
+    /// the same quiescent boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid sequence, pending proposal, incomplete
+    /// native support, or excessive state.
+    pub fn speculative_state(&self, seq_id: i32) -> Result<Vec<u8>, Eagle3SessionError> {
+        self.check_seq(seq_id)?;
+        self.require_quiescent()?;
+        Ok(capture_state(self.raw, seq_id)?)
+    }
+
+    /// Restores versioned per-sequence speculative continuation state.
+    ///
+    /// Restore the corresponding target and draft context bytes before calling
+    /// this method.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid sequence, pending proposal, excessive
+    /// input, or any version/configuration/state mismatch.
+    pub fn restore_speculative_state(
+        &mut self,
+        seq_id: i32,
+        state: &[u8],
+    ) -> Result<(), Eagle3SessionError> {
+        self.check_seq(seq_id)?;
+        self.require_quiescent()?;
+        restore_state(self.raw, seq_id, state)?;
+        Ok(())
+    }
+
+    /// Removes a target-context KV range.
+    ///
+    /// # Errors
+    ///
+    /// Returns a conversion error when an identifier or position exceeds
+    /// native `i32` bounds.
+    pub fn clear_target_kv_cache_seq(
+        &mut self,
+        seq_id: Option<u32>,
+        p0: Option<u32>,
+        p1: Option<u32>,
+    ) -> Result<bool, crate::context::kv_cache::KvCacheConversionError> {
+        self.target.clear_kv_cache_seq(seq_id, p0, p1)
+    }
+
+    /// Removes a draft-context KV range.
+    ///
+    /// # Errors
+    ///
+    /// Returns a conversion error when an identifier or position exceeds
+    /// native `i32` bounds.
+    pub fn clear_draft_kv_cache_seq(
+        &mut self,
+        seq_id: Option<u32>,
+        p0: Option<u32>,
+        p1: Option<u32>,
+    ) -> Result<bool, crate::context::kv_cache::KvCacheConversionError> {
+        self.draft.clear_kv_cache_seq(seq_id, p0, p1)
+    }
+
+    /// Returns the target context's exact sequence-state byte count.
+    pub fn target_state_seq_get_size_ext(&mut self, seq_id: i32, flags: u32) -> usize {
+        self.target.state_seq_get_size_ext(seq_id, flags)
+    }
+
+    /// Copies target context sequence state with exact native flags.
+    pub fn target_state_seq_get_data_ext(
+        &mut self,
+        dst: &mut [u8],
+        seq_id: i32,
+        flags: u32,
+    ) -> usize {
+        self.target.state_seq_get_data_ext(dst, seq_id, flags)
+    }
+
+    /// Restores target context sequence state with exact native flags.
+    pub fn target_state_seq_set_data_ext(&mut self, src: &[u8], seq_id: i32, flags: u32) -> usize {
+        self.target.state_seq_set_data_ext(src, seq_id, flags)
+    }
+
+    /// Returns the draft context's exact sequence-state byte count.
+    pub fn draft_state_seq_get_size_ext(&mut self, seq_id: i32, flags: u32) -> usize {
+        self.draft.state_seq_get_size_ext(seq_id, flags)
+    }
+
+    /// Copies draft context sequence state with exact native flags.
+    pub fn draft_state_seq_get_data_ext(
+        &mut self,
+        dst: &mut [u8],
+        seq_id: i32,
+        flags: u32,
+    ) -> usize {
+        self.draft.state_seq_get_data_ext(dst, seq_id, flags)
+    }
+
+    /// Restores draft context sequence state with exact native flags.
+    pub fn draft_state_seq_set_data_ext(&mut self, src: &[u8], seq_id: i32, flags: u32) -> usize {
+        self.draft.state_seq_set_data_ext(src, seq_id, flags)
+    }
+
+    fn require_quiescent(&self) -> Result<(), Eagle3SessionError> {
+        if let Some((index, _)) = self
+            .pending_proposals
+            .iter()
+            .enumerate()
+            .find(|(_, proposal)| proposal.is_some())
+        {
+            return Err(Eagle3SessionError::ProposalPending {
+                seq_id: i32::try_from(index).unwrap_or(i32::MAX),
+            });
+        }
+        if !unsafe { llama_cpp_sys_4::mtp_session_is_quiescent(self.raw.as_ptr()) } {
+            return Err(Eagle3SessionError::State(
+                SpeculativeStateError::NotQuiescent,
+            ));
         }
         Ok(())
     }
@@ -375,15 +659,52 @@ impl Eagle3Session {
         }
         Ok(())
     }
+
+    fn sequence_index(&self, seq_id: i32) -> Result<usize, Eagle3SessionError> {
+        self.check_seq(seq_id)?;
+        usize::try_from(seq_id)
+            .map_err(|_| Eagle3SessionError::InvalidConfig("sequence id exceeds usize"))
+    }
 }
 
-impl Drop for Eagle3Session {
+fn validate_contexts(
+    target: &LlamaContext<'_>,
+    draft: &LlamaContext<'_>,
+    config: Eagle3SessionConfig,
+) -> Result<(), Eagle3SessionError> {
+    if target.context_type() != LlamaContextType::Default
+        || draft.context_type() != LlamaContextType::Default
+    {
+        return Err(Eagle3SessionError::IncompatibleContexts(
+            "target and draft must both be Default contexts",
+        ));
+    }
+    if target.n_seq_max() < config.n_seq || draft.n_seq_max() != config.n_seq {
+        return Err(Eagle3SessionError::IncompatibleContexts(
+            "target sequence capacity is too small or draft capacity differs from n_seq",
+        ));
+    }
+    let target_layers = target.model.n_layer();
+    let layer_ids = draft.model.target_layer_ids();
+    if layer_ids.len() != 3
+        || layer_ids
+            .iter()
+            .any(|&layer| layer < 0 || layer >= target_layers)
+    {
+        return Err(Eagle3SessionError::IncompatibleContexts(
+            "draft must name exactly three in-range target extraction layers",
+        ));
+    }
+    Ok(())
+}
+
+impl Drop for Eagle3Session<'_, '_, '_> {
     fn drop(&mut self) {
         unsafe { llama_cpp_sys_4::mtp_session_free(self.raw.as_ptr()) }
     }
 }
 
-impl std::fmt::Debug for Eagle3Session {
+impl std::fmt::Debug for Eagle3Session<'_, '_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Eagle3Session")
             .field("config", &self.config)

--- a/llama-cpp-4/src/eagle.rs
+++ b/llama-cpp-4/src/eagle.rs
@@ -68,7 +68,10 @@ use crate::context::params::LlamaContextType;
 use crate::context::LlamaContext;
 use crate::llama_batch::LlamaBatch;
 use crate::speculative::MAX_SPECULATIVE_PROMPT_TOKENS;
-use crate::speculative::{capture_state, restore_state, validate_config, SpeculativeStateError};
+use crate::speculative::{
+    capture_state, restore_state, validate_config, validate_context_capacities,
+    SpeculativeContextCapacity, SpeculativeStateError,
+};
 use crate::token::LlamaToken;
 
 /// Errors raised by the EAGLE-3 draft session.
@@ -684,18 +687,55 @@ fn validate_contexts(
             "target sequence capacity is too small or draft capacity differs from n_seq",
         ));
     }
+    let required_draft = u32::try_from(config.n_draft_max)
+        .map_err(|_| Eagle3SessionError::InvalidConfig("n_draft_max exceeds u32"))?;
+    validate_context_capacities(
+        SpeculativeContextCapacity {
+            batch: target.n_batch(),
+            micro_batch: target.n_ubatch(),
+            recurrent_slots: target.n_rs_seq(),
+            recurrent_or_hybrid: target.model.is_recurrent() || target.model.is_hybrid(),
+        },
+        SpeculativeContextCapacity {
+            batch: draft.n_batch(),
+            micro_batch: draft.n_ubatch(),
+            recurrent_slots: draft.n_rs_seq(),
+            recurrent_or_hybrid: draft.model.is_recurrent() || draft.model.is_hybrid(),
+        },
+        required_draft,
+    )
+    .map_err(Eagle3SessionError::IncompatibleContexts)?;
     let target_layers = target.model.n_layer();
-    let layer_ids = draft.model.target_layer_ids();
-    if layer_ids.len() != 3
-        || layer_ids
-            .iter()
-            .any(|&layer| layer < 0 || layer >= target_layers)
-    {
+    let target_architecture = target
+        .model
+        .meta_val_str("general.architecture", 64)
+        .map_err(|_| {
+            Eagle3SessionError::IncompatibleContexts(
+                "target model architecture metadata is unavailable",
+            )
+        })?;
+    if !valid_target_layer_ids(
+        draft.model.target_layer_ids(),
+        target_layers,
+        target_architecture == "gpt-oss",
+    ) {
         return Err(Eagle3SessionError::IncompatibleContexts(
-            "draft must name exactly three in-range target extraction layers",
+            "draft must name exactly three supported target extraction sites",
         ));
     }
     Ok(())
+}
+
+fn valid_target_layer_ids(
+    layer_ids: &[i32],
+    target_layers: i32,
+    terminal_nextn_site: bool,
+) -> bool {
+    target_layers > 0
+        && layer_ids.len() == 3
+        && layer_ids.iter().all(|&layer| {
+            layer >= 0 && (layer < target_layers || (layer == target_layers && terminal_nextn_site))
+        })
 }
 
 impl Drop for Eagle3Session<'_, '_, '_> {
@@ -709,5 +749,20 @@ impl std::fmt::Debug for Eagle3Session<'_, '_, '_> {
         f.debug_struct("Eagle3Session")
             .field("config", &self.config)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::valid_target_layer_ids;
+
+    #[test]
+    fn validates_transformer_and_terminal_nextn_sites() {
+        assert!(valid_target_layer_ids(&[1, 4, 7], 8, false));
+        assert!(!valid_target_layer_ids(&[1, 4], 8, false));
+        assert!(!valid_target_layer_ids(&[1, -1, 7], 8, false));
+        assert!(!valid_target_layer_ids(&[1, 4, 8], 8, false));
+        assert!(valid_target_layer_ids(&[1, 4, 8], 8, true));
+        assert!(!valid_target_layer_ids(&[1, 4, 9], 8, true));
     }
 }

--- a/llama-cpp-4/src/lib.rs
+++ b/llama-cpp-4/src/lib.rs
@@ -99,6 +99,7 @@ pub mod mtp;
 pub mod prelude;
 pub mod quantize;
 pub mod sampling;
+pub mod speculative;
 pub mod token;
 pub mod token_type;
 
@@ -177,6 +178,9 @@ pub enum LlamaContextLoadError {
 /// Failed to decode a batch.
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum DecodeError {
+    /// A Rust tensor callback failed or unwound after native execution began.
+    #[error(transparent)]
+    TensorCallback(#[from] context::TensorCallbackFailure),
     /// No kv cache slot was available.
     #[error("Decode Error 1: NoKvCacheSlot")]
     NoKvCacheSlot,
@@ -617,12 +621,42 @@ pub unsafe fn opt_param_filter_all(
 pub use context::params::LlamaContextParams;
 /// One captured intermediate tensor from [`TensorCapture`].
 pub use context::CapturedTensor;
+/// Typed retained storage from an owned tensor transaction.
+pub use context::CapturedTensorData;
 /// An inference context tied to a model.
 pub use context::LlamaContext;
 /// Per-buffer memory usage entry from [`LlamaContext::memory_breakdown`].
 pub use context::MemoryBreakdownEntry;
+/// Access granted to an exact tensor selector.
+pub use context::TensorAccess;
+/// Exact sequence and causal-position metadata for one tensor row.
+pub use context::TensorBatchRow;
+/// A contained tensor callback failure.
+pub use context::TensorCallbackFailure;
 /// Hook `cb_eval` during decode to copy named graph tensors (layer hidden states, …).
 pub use context::TensorCapture;
+/// Typed Rust-owned tensor storage supplied to a transaction handler.
+pub use context::TensorDataMut;
+/// Element representation required by an exact tensor selector.
+pub use context::TensorElementType;
+/// Mapping between selected tensor rows and the decode batch.
+pub use context::TensorRowMapping;
+/// Exact bounded graph-node contract.
+pub use context::TensorSelector;
+/// Validated tensor dimensions.
+pub use context::TensorShape;
+/// One synchronous owned tensor transaction.
+pub use context::TensorTransaction;
+/// Error returned by a transaction handler or selector validator.
+pub use context::TensorTransactionError;
+/// Safe synchronous tensor transaction handler.
+pub use context::TensorTransactionHandler;
+/// Owned pinned tensor callback program.
+pub use context::TensorTransactions;
+/// Native write-back decision returned by a transaction handler.
+pub use context::TensorWriteback;
+/// Complete retained tensor from one transaction.
+pub use context::TransactionalTensorCapture;
 /// Initialise the llama.cpp backend and hardware drivers.
 pub use llama_backend::LlamaBackend;
 /// Micro-batch submitted to [`LlamaContext::decode`].
@@ -637,5 +671,7 @@ pub use model::LlamaModel;
 pub use model::Special;
 /// Sampler chain for token selection.
 pub use sampling::LlamaSampler;
+/// Failure while capturing or restoring versioned speculative state.
+pub use speculative::SpeculativeStateError;
 /// A single vocabulary token id.
 pub use token::LlamaToken;

--- a/llama-cpp-4/src/lib.rs
+++ b/llama-cpp-4/src/lib.rs
@@ -344,6 +344,17 @@ pub enum TokenToStringError {
     /// There was insufficient buffer space to convert the token to a string.
     #[error("Insufficient Buffer Space {0}")]
     InsufficientBufferSpace(c_int),
+    /// Caller-owned storage exceeds llama.cpp's signed buffer-length type.
+    #[error("piece buffer capacity {0} exceeds the native c_int bound")]
+    BufferCapacityExceeded(usize),
+    /// llama.cpp reported a positive piece length outside the supplied buffer.
+    #[error("native piece length {returned} exceeds buffer capacity {capacity}")]
+    NativePieceLength {
+        /// Positive length returned by llama.cpp.
+        returned: c_int,
+        /// Supplied caller-owned capacity.
+        capacity: usize,
+    },
     /// The token was not valid utf8.
     #[error("FromUtf8Error {0}")]
     FromUtf8Error(#[from] FromUtf8Error),
@@ -355,9 +366,20 @@ pub enum StringToTokenError {
     /// the string contained a null byte and thus could not be converted to a c string.
     #[error("{0}")]
     NulError(#[from] NulError),
+    /// The string contained an interior NUL at the reported byte.
+    #[error("input contains an interior NUL at byte {0}")]
+    InteriorNul(usize),
     #[error("{0}")]
     /// Failed to convert a provided integer to a [`c_int`].
     CIntConversionError(#[from] std::num::TryFromIntError),
+    /// llama.cpp reported a positive token count outside the supplied buffer.
+    #[error("native token count {returned} exceeds buffer capacity {capacity}")]
+    NativeTokenCount {
+        /// Positive count returned by llama.cpp.
+        returned: c_int,
+        /// Supplied caller-owned capacity.
+        capacity: usize,
+    },
 }
 
 /// Failed to apply model chat template.

--- a/llama-cpp-4/src/model.rs
+++ b/llama-cpp-4/src/model.rs
@@ -305,12 +305,25 @@ impl LlamaVocab {
     ///
     /// Returns an error if the text pointer is null or not valid UTF-8.
     pub fn get_text(&self, token: LlamaToken) -> Result<&str, StringFromModelError> {
+        let bytes = self.get_text_bytes(token)?;
+        std::str::from_utf8(bytes).map_err(StringFromModelError::Utf8Error)
+    }
+
+    /// Get the exact byte representation stored for a vocabulary token.
+    ///
+    /// Unlike [`Self::get_text`], this method does not require the token text
+    /// to be valid UTF-8.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if llama.cpp reports a null text pointer.
+    pub fn get_text_bytes(&self, token: LlamaToken) -> Result<&[u8], StringFromModelError> {
         let ptr = unsafe { llama_cpp_sys_4::llama_vocab_get_text(self.vocab.as_ref(), token.0) };
         if ptr.is_null() {
             return Err(StringFromModelError::ReturnedError(-1));
         }
         let cstr = unsafe { CStr::from_ptr(ptr) };
-        cstr.to_str().map_err(StringFromModelError::Utf8Error)
+        Ok(cstr.to_bytes())
     }
 
     /// Get the score of a token.
@@ -2007,7 +2020,7 @@ impl LlamaModel {
     pub fn new_context(
         &self,
         _: &LlamaBackend,
-        params: LlamaContextParams,
+        mut params: LlamaContextParams,
     ) -> Result<LlamaContext<'_>, LlamaContextLoadError> {
         // Apply TurboQuant attn-rotation preference before the KV cache is
         // initialised inside llama_init_from_model.
@@ -2023,7 +2036,9 @@ impl LlamaModel {
             // (respect explicit user env var).
         }
 
+        let context_type = params.ctx_type();
         let context_params = params.context_params;
+        let embeddings_enabled = params.embeddings();
         let context = unsafe { llama_init_from_model(self.model.as_ptr(), context_params) };
 
         // Restore the env-var to its previous state.
@@ -2037,7 +2052,14 @@ impl LlamaModel {
         }
 
         let context = NonNull::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
-        Ok(LlamaContext::new(self, context, params.embeddings()))
+        let tensor_transactions = params.tensor_transactions.take();
+        Ok(LlamaContext::new(
+            self,
+            context,
+            embeddings_enabled,
+            context_type,
+            tensor_transactions,
+        ))
     }
 
     /// Apply the model's chat template to a sequence of messages.

--- a/llama-cpp-4/src/model.rs
+++ b/llama-cpp-4/src/model.rs
@@ -831,16 +831,75 @@ impl LlamaModel {
         token: LlamaToken,
         special: Special,
     ) -> Result<Vec<u8>, TokenToStringError> {
-        match self.token_to_raw_bytes_with_size(token, 32, special, None) {
-            // llama.cpp reports the required size as a negative value; retry once
-            // with exactly that many bytes so long pieces never spuriously fail.
-            Err(TokenToStringError::InsufficientBufferSpace(needed)) if needed < 0 => {
-                match usize::try_from(-needed) {
-                    Ok(size) => self.token_to_raw_bytes_with_size(token, size, special, None),
-                    Err(_) => Err(TokenToStringError::InsufficientBufferSpace(needed)),
+        let mut buffer = Vec::with_capacity(32);
+        self.token_to_raw_bytes_into(token, special, &mut buffer)?;
+        Ok(buffer)
+    }
+
+    /// Converts one token to raw piece bytes in caller-owned reusable storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if llama.cpp reports an unknown token or an excessive
+    /// required buffer length.
+    pub fn token_to_raw_bytes_into(
+        &self,
+        token: LlamaToken,
+        special: Special,
+        buffer: &mut Vec<u8>,
+    ) -> Result<(), TokenToStringError> {
+        let special = matches!(special, Special::Tokenize);
+        buffer.clear();
+        if buffer.capacity() < 32 {
+            buffer.reserve(32);
+        }
+        loop {
+            let capacity = buffer.capacity();
+            buffer.resize(capacity, 0);
+            let native_capacity = c_int::try_from(capacity)
+                .map_err(|_| TokenToStringError::BufferCapacityExceeded(capacity))?;
+            let size = unsafe {
+                llama_token_to_piece(
+                    self.get_vocab().vocab.as_ref(),
+                    token.0,
+                    buffer.as_mut_ptr().cast::<c_char>(),
+                    native_capacity,
+                    0,
+                    special,
+                )
+            };
+            match size {
+                0 => {
+                    buffer.clear();
+                    return Err(TokenToStringError::UnknownTokenType);
+                }
+                needed if needed.is_negative() => {
+                    let required = usize::try_from(-needed)
+                        .map_err(|_| TokenToStringError::InsufficientBufferSpace(needed))?;
+                    buffer.clear();
+                    if required <= capacity {
+                        return Err(TokenToStringError::InsufficientBufferSpace(needed));
+                    }
+                    buffer.reserve_exact(required);
+                }
+                written => {
+                    let written = usize::try_from(written).map_err(|_| {
+                        TokenToStringError::NativePieceLength {
+                            returned: written,
+                            capacity,
+                        }
+                    })?;
+                    if written > capacity {
+                        buffer.clear();
+                        return Err(TokenToStringError::NativePieceLength {
+                            returned: size,
+                            capacity,
+                        });
+                    }
+                    buffer.truncate(written);
+                    return Ok(());
                 }
             }
-            other => other,
         }
     }
 
@@ -933,24 +992,44 @@ impl LlamaModel {
         str: &str,
         add_bos: AddBos,
     ) -> Result<Vec<LlamaToken>, StringToTokenError> {
+        let mut buffer = Vec::new();
+        self.str_to_token_into(str, add_bos, &mut buffer)?;
+        Ok(buffer)
+    }
+
+    /// Tokenizes into caller-owned storage so repeated operations can reuse
+    /// their allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the text contains NUL or its length exceeds the
+    /// native integer representation.
+    pub fn str_to_token_into(
+        &self,
+        str: &str,
+        add_bos: AddBos,
+        buffer: &mut Vec<LlamaToken>,
+    ) -> Result<(), StringToTokenError> {
         let add_bos = match add_bos {
             AddBos::Always => true,
             AddBos::Never => false,
         };
-
+        if let Some(position) = str.as_bytes().iter().position(|byte| *byte == 0) {
+            return Err(StringToTokenError::InteriorNul(position));
+        }
         let tokens_estimation = std::cmp::max(8, (str.len() / 2) + usize::from(add_bos));
-        let mut buffer = Vec::with_capacity(tokens_estimation);
-
-        let c_string = CString::new(str)?;
-        let buffer_capacity =
-            c_int::try_from(buffer.capacity()).expect("buffer capacity should fit into a c_int");
-
+        buffer.clear();
+        if buffer.capacity() < tokens_estimation {
+            buffer.reserve(tokens_estimation);
+        }
+        let buffer_capacity = c_int::try_from(buffer.capacity())?;
+        let text_length = c_int::try_from(str.len())?;
         let size = unsafe {
             llama_tokenize(
                 self.get_vocab().vocab.as_ref(),
-                c_string.as_ptr(),
-                c_int::try_from(c_string.as_bytes().len())?,
-                buffer.as_mut_ptr(),
+                str.as_ptr().cast(),
+                text_length,
+                buffer.as_mut_ptr().cast(),
                 buffer_capacity,
                 add_bos,
                 true,
@@ -960,14 +1039,18 @@ impl LlamaModel {
         // if we fail the first time we can resize the vector to the correct size and try again. This should never fail.
         // as a result - size is guaranteed to be positive here.
         let size = if size.is_negative() {
-            buffer.reserve_exact(usize::try_from(-size).expect("usize's are larger "));
+            let required = usize::try_from(size.unsigned_abs())?;
+            if buffer.capacity() < required {
+                buffer.reserve_exact(required);
+            }
+            let retry_capacity = c_int::try_from(buffer.capacity())?;
             unsafe {
                 llama_tokenize(
                     self.get_vocab().vocab.as_ref(),
-                    c_string.as_ptr(),
-                    c_int::try_from(c_string.as_bytes().len())?,
-                    buffer.as_mut_ptr(),
-                    -size,
+                    str.as_ptr().cast(),
+                    text_length,
+                    buffer.as_mut_ptr().cast(),
+                    retry_capacity,
                     add_bos,
                     true,
                 )
@@ -976,11 +1059,43 @@ impl LlamaModel {
             size
         };
 
-        let size = usize::try_from(size).expect("size is positive and usize ");
+        let native_size = size;
+        let size = usize::try_from(native_size)?;
+        if size > buffer.capacity() {
+            return Err(StringToTokenError::NativeTokenCount {
+                returned: native_size,
+                capacity: buffer.capacity(),
+            });
+        }
 
-        // Safety: `size` < `capacity` and llama-cpp has initialized elements up to `size`
+        // Safety: `size <= capacity` and llama.cpp initialized elements up to `size`.
         unsafe { buffer.set_len(size) }
-        Ok(buffer.into_iter().map(LlamaToken).collect())
+        Ok(())
+    }
+
+    /// Counts tokens without materializing token identifiers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the text contains NUL or its length/count cannot
+    /// be represented by the native API.
+    pub fn str_token_count(&self, str: &str, add_bos: AddBos) -> Result<usize, StringToTokenError> {
+        let add_bos = matches!(add_bos, AddBos::Always);
+        if let Some(position) = str.as_bytes().iter().position(|byte| *byte == 0) {
+            return Err(StringToTokenError::InteriorNul(position));
+        }
+        let size = unsafe {
+            llama_tokenize(
+                self.get_vocab().vocab.as_ref(),
+                str.as_ptr().cast(),
+                c_int::try_from(str.len())?,
+                std::ptr::null_mut(),
+                0,
+                add_bos,
+                true,
+            )
+        };
+        Ok(usize::try_from(i64::from(size).unsigned_abs())?)
     }
 
     /// Get the type of a token.

--- a/llama-cpp-4/src/model/params.rs
+++ b/llama-cpp-4/src/model/params.rs
@@ -145,7 +145,6 @@ impl LlamaModelParams {
     #[must_use]
     pub fn load_mode(&self) -> LlamaLoadMode {
         match self.params.load_mode {
-            llama_cpp_sys_4::LLAMA_LOAD_MODE_NONE => LlamaLoadMode::None,
             llama_cpp_sys_4::LLAMA_LOAD_MODE_MMAP => LlamaLoadMode::Mmap,
             llama_cpp_sys_4::LLAMA_LOAD_MODE_MLOCK => LlamaLoadMode::Mlock,
             llama_cpp_sys_4::LLAMA_LOAD_MODE_MMAP_MLOCK => LlamaLoadMode::MmapMlock,

--- a/llama-cpp-4/src/model/params.rs
+++ b/llama-cpp-4/src/model/params.rs
@@ -226,9 +226,6 @@ impl LlamaModelParams {
 /// ```
 /// # use llama_cpp_4::model::params::LlamaModelParams;
 /// let params = LlamaModelParams::default();
-/// #[cfg(not(target_os = "macos"))]
-/// assert_eq!(params.n_gpu_layers(), 0, "n_gpu_layers should be 0");
-/// #[cfg(target_os = "macos")]
 /// assert_eq!(params.n_gpu_layers(), -1, "n_gpu_layers should be -1 (all layers)");
 /// assert_eq!(params.main_gpu(), 0, "main_gpu should be 0");
 /// assert_eq!(params.vocab_only(), false, "vocab_only should be false");

--- a/llama-cpp-4/src/model/params.rs
+++ b/llama-cpp-4/src/model/params.rs
@@ -8,6 +8,22 @@ use std::ptr::null;
 
 pub mod kv_overrides;
 
+/// Exact model-file loading strategy exposed by llama.cpp.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum LlamaLoadMode {
+    /// No memory mapping, locking, or direct I/O.
+    None = llama_cpp_sys_4::LLAMA_LOAD_MODE_NONE,
+    /// Memory-map model files when supported.
+    Mmap = llama_cpp_sys_4::LLAMA_LOAD_MODE_MMAP,
+    /// Read model files normally and lock loaded pages in memory.
+    Mlock = llama_cpp_sys_4::LLAMA_LOAD_MODE_MLOCK,
+    /// Memory-map model files and lock mapped pages in memory.
+    MmapMlock = llama_cpp_sys_4::LLAMA_LOAD_MODE_MMAP_MLOCK,
+    /// Use direct I/O when supported.
+    DirectIo = llama_cpp_sys_4::LLAMA_LOAD_MODE_DIRECT_IO,
+}
+
 /// A safe wrapper around `llama_model_params`.
 #[allow(clippy::module_name_repetitions)]
 pub struct LlamaModelParams {
@@ -21,8 +37,7 @@ impl Debug for LlamaModelParams {
             .field("n_gpu_layers", &self.params.n_gpu_layers)
             .field("main_gpu", &self.params.main_gpu)
             .field("vocab_only", &self.params.vocab_only)
-            .field("use_mmap", &self.params.use_mmap)
-            .field("use_mlock", &self.params.use_mlock)
+            .field("load_mode", &self.load_mode())
             .field("kv_overrides", &"vec of kv_overrides")
             .finish()
     }
@@ -126,16 +141,35 @@ impl LlamaModelParams {
         self.params.vocab_only
     }
 
+    /// Returns the exact model-file loading strategy.
+    #[must_use]
+    pub fn load_mode(&self) -> LlamaLoadMode {
+        match self.params.load_mode {
+            llama_cpp_sys_4::LLAMA_LOAD_MODE_NONE => LlamaLoadMode::None,
+            llama_cpp_sys_4::LLAMA_LOAD_MODE_MMAP => LlamaLoadMode::Mmap,
+            llama_cpp_sys_4::LLAMA_LOAD_MODE_MLOCK => LlamaLoadMode::Mlock,
+            llama_cpp_sys_4::LLAMA_LOAD_MODE_MMAP_MLOCK => LlamaLoadMode::MmapMlock,
+            llama_cpp_sys_4::LLAMA_LOAD_MODE_DIRECT_IO => LlamaLoadMode::DirectIo,
+            _ => LlamaLoadMode::None,
+        }
+    }
+
     /// use mmap if possible
     #[must_use]
     pub fn use_mmap(&self) -> bool {
-        self.params.use_mmap
+        matches!(
+            self.load_mode(),
+            LlamaLoadMode::Mmap | LlamaLoadMode::MmapMlock
+        )
     }
 
     /// force system to keep model in RAM
     #[must_use]
     pub fn use_mlock(&self) -> bool {
-        self.params.use_mlock
+        matches!(
+            self.load_mode(),
+            LlamaLoadMode::Mlock | LlamaLoadMode::MmapMlock
+        )
     }
 
     /// sets the number of gpu layers to offload to the GPU.
@@ -168,10 +202,23 @@ impl LlamaModelParams {
         self
     }
 
+    /// Sets the exact model-file loading strategy.
+    #[must_use]
+    pub fn with_load_mode(mut self, load_mode: LlamaLoadMode) -> Self {
+        self.params.load_mode = load_mode as llama_cpp_sys_4::llama_load_mode;
+        self
+    }
+
     /// sets `use_mlock`
     #[must_use]
     pub fn with_use_mlock(mut self, use_mlock: bool) -> Self {
-        self.params.use_mlock = use_mlock;
+        let load_mode = match (self.use_mmap(), use_mlock) {
+            (true, true) => LlamaLoadMode::MmapMlock,
+            (true, false) => LlamaLoadMode::Mmap,
+            (false, true) => LlamaLoadMode::Mlock,
+            (false, false) => LlamaLoadMode::None,
+        };
+        self.params.load_mode = load_mode as llama_cpp_sys_4::llama_load_mode;
         self
     }
 }

--- a/llama-cpp-4/src/mtp.rs
+++ b/llama-cpp-4/src/mtp.rs
@@ -29,8 +29,8 @@
 //!
 //! let n_draft_max = 3;
 //!
-//! let target = model.new_context(&backend, LlamaContextParams::default())?;
-//! let draft = model.new_context(
+//! let mut target = model.new_context(&backend, LlamaContextParams::default())?;
+//! let mut draft = model.new_context(
 //!     &backend,
 //!     LlamaContextParams::default()
 //!         .with_ctx_type(LlamaContextType::Mtp)
@@ -38,7 +38,7 @@
 //! )?;
 //!
 //! let config = MtpSessionConfig::new(1, n_draft_max).with_p_min(0.0);
-//! let mut session = MtpSession::new_with_config(&target, &draft, config)?;
+//! let mut session = MtpSession::new_with_config(&mut target, &mut draft, config)?;
 //! ```
 //!
 //! # Speculative loop
@@ -47,10 +47,7 @@
 //!
 //! ```ignore
 //! // 1. Target prefill or verify decode (you build the batch)
-//! target.decode(&mut batch)?;
-//!
-//! // 2. Tell MTP about the batch just decoded on the target
-//! session.process(&batch)?;
+//! session.decode_target_and_process(&mut batch)?;
 //!
 //! // 3. Ask for draft tokens starting from the last accepted token
 //! let drafts = session.draft(0, n_past, last_token)?;
@@ -90,10 +87,15 @@
 //! ```
 //!
 
+use std::marker::PhantomData;
 use std::ptr::NonNull;
+use std::rc::Rc;
 
+use crate::context::params::LlamaContextType;
 use crate::context::LlamaContext;
 use crate::llama_batch::LlamaBatch;
+use crate::speculative::MAX_SPECULATIVE_PROMPT_TOKENS;
+use crate::speculative::{capture_state, restore_state, validate_config, SpeculativeStateError};
 use crate::token::LlamaToken;
 
 /// Errors raised by the MTP draft session.
@@ -108,6 +110,31 @@ pub enum MtpSessionError {
     #[error("mtp_session_process failed (see llama.cpp logs)")]
     Process,
 
+    /// Native prompt initialization failed or raised a contained exception.
+    #[error("mtp_session_begin failed")]
+    Begin,
+
+    /// Native draft generation failed or raised a contained exception.
+    #[error("mtp_session_draft failed")]
+    Draft,
+
+    /// Native proposal acceptance failed or raised a contained exception.
+    #[error("mtp_session_accept failed")]
+    Accept,
+
+    /// Prompt storage exceeds the safe speculative-session bound.
+    #[error("prompt has {size} tokens, exceeding the {maximum}-token bound")]
+    PromptTooLong {
+        /// Caller-supplied prompt-token count.
+        size: usize,
+        /// Inclusive safe prompt-token bound.
+        maximum: usize,
+    },
+
+    /// The supplied contexts do not satisfy the native MTP contract.
+    #[error("incompatible MTP contexts: {0}")]
+    IncompatibleContexts(&'static str),
+
     /// Caller passed a sequence id outside `[0, n_seq)`.
     #[error("sequence id {seq_id} out of range (n_seq = {n_seq})")]
     BadSeqId {
@@ -120,6 +147,37 @@ pub enum MtpSessionError {
     /// Invalid session configuration (e.g. `n_draft_max <= 0`).
     #[error("invalid MTP session config: {0}")]
     InvalidConfig(&'static str),
+
+    /// The target context failed to decode.
+    #[error("target decode failed: {0}")]
+    Decode(#[from] crate::DecodeError),
+
+    /// An operation requires all draft proposals to be completed first.
+    #[error("sequence {seq_id} still has an unaccepted draft proposal")]
+    ProposalPending {
+        /// Sequence with a pending proposal.
+        seq_id: i32,
+    },
+
+    /// `accept` was called without a preceding nonempty draft.
+    #[error("sequence {seq_id} has no draft proposal to accept")]
+    NoPendingProposal {
+        /// Sequence without a pending proposal.
+        seq_id: i32,
+    },
+
+    /// The accepted prefix exceeds the proposal length.
+    #[error("accepted {accepted} tokens from a {proposed}-token proposal")]
+    AcceptedTooMany {
+        /// Accepted prefix length.
+        accepted: u16,
+        /// Exact proposal length.
+        proposed: usize,
+    },
+
+    /// Exact speculative-state capture or restore failed.
+    #[error(transparent)]
+    State(#[from] SpeculativeStateError),
 }
 
 /// Parameters for [`MtpSession::new_with_config`].
@@ -194,21 +252,19 @@ impl MtpSessionConfig {
 /// Drops the underlying `mtp_session *` (and the C++ `common_speculative *`
 /// it holds) when freed.
 ///
-/// # Lifetime contract (manual)
-///
-/// The session holds raw pointers to both the target and draft
-/// [`LlamaContext`]s. **The caller must keep both contexts alive (i.e. not
-/// drop them) for as long as the session exists.**
-pub struct MtpSession {
+/// The session exclusively borrows both contexts for its Rust lifetime, so
+/// neither can be moved, accessed mutably, or dropped while native code retains
+/// their pointers. It is deliberately neither `Send` nor `Sync`.
+pub struct MtpSession<'ctx, 'model> {
     raw: NonNull<llama_cpp_sys_4::mtp_session>,
     config: MtpSessionConfig,
+    target: &'ctx mut LlamaContext<'model>,
+    draft: &'ctx mut LlamaContext<'model>,
+    pending_proposals: Vec<Option<usize>>,
+    not_send_sync: PhantomData<Rc<()>>,
 }
 
-// SAFETY: the underlying C++ session owns its own state and is not tied to
-// any TLS. Concurrent calls from multiple threads are NOT safe.
-unsafe impl Send for MtpSession {}
-
-impl MtpSession {
+impl<'ctx, 'model> MtpSession<'ctx, 'model> {
     /// Construct an MTP draft session with upstream defaults for `n_min` and
     /// `p_min`.
     ///
@@ -217,15 +273,15 @@ impl MtpSession {
     /// # Examples
     ///
     /// ```ignore
-    /// let mut session = MtpSession::new(&target, &draft, 1, 3)?;
+    /// let mut session = MtpSession::new(&mut target, &mut draft, 1, 3)?;
     /// ```
     ///
     /// # Errors
     ///
     /// Returns [`MtpSessionError::Init`] or [`MtpSessionError::InvalidConfig`].
     pub fn new(
-        target: &LlamaContext<'_>,
-        draft: &LlamaContext<'_>,
+        target: &'ctx mut LlamaContext<'model>,
+        draft: &'ctx mut LlamaContext<'model>,
         n_seq: u32,
         n_draft_max: i32,
     ) -> Result<Self, MtpSessionError> {
@@ -244,23 +300,22 @@ impl MtpSession {
     /// ```ignore
     /// let config = MtpSessionConfig::new(1, 1)
     ///     .with_p_min(0.0); // match upstream default after #23269
-    /// let session = MtpSession::new_with_config(&target, &draft, config)?;
+    /// let session = MtpSession::new_with_config(&mut target, &mut draft, config)?;
     /// ```
     ///
     /// # Errors
     ///
     /// Returns [`MtpSessionError::Init`] or [`MtpSessionError::InvalidConfig`].
     pub fn new_with_config(
-        target: &LlamaContext<'_>,
-        draft: &LlamaContext<'_>,
+        target: &'ctx mut LlamaContext<'model>,
+        draft: &'ctx mut LlamaContext<'model>,
         config: MtpSessionConfig,
     ) -> Result<Self, MtpSessionError> {
-        if config.n_seq == 0 {
-            return Err(MtpSessionError::InvalidConfig("n_seq must be > 0"));
-        }
-        if config.n_draft_max <= 0 {
-            return Err(MtpSessionError::InvalidConfig("n_draft_max must be > 0"));
-        }
+        validate_config(config.n_seq, config.n_draft_max, config.n_min, config.p_min)
+            .map_err(MtpSessionError::InvalidConfig)?;
+        validate_contexts(target, draft, config)?;
+        let sequence_slots = usize::try_from(config.n_seq)
+            .map_err(|_| MtpSessionError::InvalidConfig("n_seq exceeds usize"))?;
 
         // `MTP_SPEC_TYPE_*` is `c_uint` under clang/gcc and `c_int` under MSVC;
         // `as i32` compiles on both. The allow covers the clang/gcc case.
@@ -281,7 +336,14 @@ impl MtpSession {
             )
         };
         let raw = NonNull::new(raw).ok_or(MtpSessionError::Init)?;
-        Ok(Self { raw, config })
+        Ok(Self {
+            raw,
+            config,
+            target,
+            draft,
+            pending_proposals: vec![None; sequence_slots],
+            not_send_sync: PhantomData,
+        })
     }
 
     /// Session configuration passed at construction.
@@ -334,6 +396,65 @@ impl MtpSession {
         self.config.n_seq
     }
 
+    /// Returns shared access to the target context for reading logits,
+    /// embeddings, and model metadata.
+    #[must_use]
+    pub fn target_context(&self) -> &LlamaContext<'model> {
+        self.target
+    }
+
+    /// Returns exclusive access to the target context while this wrapper
+    /// retains native pointer ownership.
+    #[must_use]
+    pub fn target_context_mut(&mut self) -> &mut LlamaContext<'model> {
+        self.target
+    }
+
+    /// Returns shared access to the draft context for metadata inspection.
+    #[must_use]
+    pub fn draft_context(&self) -> &LlamaContext<'model> {
+        self.draft
+    }
+
+    /// Returns exclusive access to the draft context while this wrapper
+    /// retains native pointer ownership.
+    #[must_use]
+    pub fn draft_context_mut(&mut self) -> &mut LlamaContext<'model> {
+        self.draft
+    }
+
+    /// Decodes on the target and immediately harvests the same batch into MTP.
+    ///
+    /// This is the causal target boundary required by the native draft
+    /// implementation. A failed decode is never passed to `process`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a target [`crate::DecodeError`] or native process failure.
+    pub fn decode_target_and_process(
+        &mut self,
+        batch: &mut LlamaBatch,
+    ) -> Result<(), MtpSessionError> {
+        self.decode_target(batch)?;
+        self.process(batch)
+    }
+
+    /// Decodes one batch on the exclusively held target context.
+    ///
+    /// Use [`Self::decode_target_and_process`] unless mechanics must run
+    /// between target decode and draft-state harvesting. This method remains
+    /// available while a draft proposal is pending because that is the target
+    /// verification phase; proposal creation, begin, and state access retain
+    /// their stricter lifecycle checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns a target [`crate::DecodeError`].
+    pub fn decode_target(&mut self, batch: &mut LlamaBatch) -> Result<(), MtpSessionError> {
+        self.target.decode(batch)?;
+        Ok(())
+    }
+
     /// Log speculative-decoding statistics (draft/accept counts and timings) via
     /// llama.cpp `LOG_INF`. Install a log callback with [`crate::log_set`] to
     /// capture output.
@@ -365,13 +486,23 @@ impl MtpSession {
     /// Returns [`MtpSessionError::BadSeqId`] if `seq_id` is out of range.
     pub fn begin(&mut self, seq_id: i32, prompt: &[LlamaToken]) -> Result<(), MtpSessionError> {
         self.check_seq(seq_id)?;
-        unsafe {
+        self.require_quiescent()?;
+        if prompt.len() > MAX_SPECULATIVE_PROMPT_TOKENS {
+            return Err(MtpSessionError::PromptTooLong {
+                size: prompt.len(),
+                maximum: MAX_SPECULATIVE_PROMPT_TOKENS,
+            });
+        }
+        let ok = unsafe {
             llama_cpp_sys_4::mtp_session_begin(
                 self.raw.as_ptr(),
                 seq_id,
                 prompt.as_ptr().cast(),
                 prompt.len(),
-            );
+            )
+        };
+        if !ok {
+            return Err(MtpSessionError::Begin);
         }
         Ok(())
     }
@@ -427,12 +558,16 @@ impl MtpSession {
         id_last: LlamaToken,
     ) -> Result<Vec<LlamaToken>, MtpSessionError> {
         self.check_seq(seq_id)?;
+        let sequence_index = self.sequence_index(seq_id)?;
+        if self.pending_proposals[sequence_index].is_some() {
+            return Err(MtpSessionError::ProposalPending { seq_id });
+        }
 
         let cap = usize::try_from(self.config.n_draft_max.max(0)).unwrap_or(0);
         let mut buf: Vec<i32> = vec![0; cap];
         let mut out_n = i32::try_from(cap).unwrap_or(i32::MAX);
 
-        unsafe {
+        let ok = unsafe {
             llama_cpp_sys_4::mtp_session_draft(
                 self.raw.as_ptr(),
                 seq_id,
@@ -440,11 +575,17 @@ impl MtpSession {
                 id_last.0,
                 buf.as_mut_ptr(),
                 &raw mut out_n,
-            );
+            )
+        };
+        if !ok {
+            return Err(MtpSessionError::Draft);
         }
 
         let n = usize::try_from(out_n.max(0)).unwrap_or(0);
         buf.truncate(n);
+        if n > 0 {
+            self.pending_proposals[sequence_index] = Some(n);
+        }
         Ok(buf.into_iter().map(LlamaToken).collect())
     }
 
@@ -464,8 +605,149 @@ impl MtpSession {
     /// Returns [`MtpSessionError::BadSeqId`] if `seq_id` is out of range.
     pub fn accept(&mut self, seq_id: i32, n_accepted: u16) -> Result<(), MtpSessionError> {
         self.check_seq(seq_id)?;
-        unsafe {
-            llama_cpp_sys_4::mtp_session_accept(self.raw.as_ptr(), seq_id, n_accepted);
+        let sequence_index = self.sequence_index(seq_id)?;
+        let proposed = self.pending_proposals[sequence_index]
+            .ok_or(MtpSessionError::NoPendingProposal { seq_id })?;
+        if usize::from(n_accepted) > proposed {
+            return Err(MtpSessionError::AcceptedTooMany {
+                accepted: n_accepted,
+                proposed,
+            });
+        }
+        let ok =
+            unsafe { llama_cpp_sys_4::mtp_session_accept(self.raw.as_ptr(), seq_id, n_accepted) };
+        if !ok {
+            return Err(MtpSessionError::Accept);
+        }
+        self.pending_proposals[sequence_index] = None;
+        Ok(())
+    }
+
+    /// Returns `true` when every draft proposal has been completed.
+    #[must_use]
+    pub fn is_quiescent(&self) -> bool {
+        self.pending_proposals.iter().all(Option::is_none)
+            && unsafe { llama_cpp_sys_4::mtp_session_is_quiescent(self.raw.as_ptr()) }
+    }
+
+    /// Captures versioned per-sequence speculative continuation state.
+    ///
+    /// Target and draft context bytes are separate and must be checkpointed at
+    /// the same quiescent boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid sequence, pending proposal, incomplete
+    /// native support, or excessive state.
+    pub fn speculative_state(&self, seq_id: i32) -> Result<Vec<u8>, MtpSessionError> {
+        self.check_seq(seq_id)?;
+        self.require_quiescent()?;
+        Ok(capture_state(self.raw, seq_id)?)
+    }
+
+    /// Restores versioned per-sequence speculative continuation state.
+    ///
+    /// Restore the corresponding target and draft context bytes before calling
+    /// this method.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid sequence, pending proposal, excessive
+    /// input, or any version/configuration/state mismatch.
+    pub fn restore_speculative_state(
+        &mut self,
+        seq_id: i32,
+        state: &[u8],
+    ) -> Result<(), MtpSessionError> {
+        self.check_seq(seq_id)?;
+        self.require_quiescent()?;
+        restore_state(self.raw, seq_id, state)?;
+        Ok(())
+    }
+
+    /// Removes a target-context KV range.
+    ///
+    /// # Errors
+    ///
+    /// Returns a conversion error when an identifier or position exceeds
+    /// native `i32` bounds.
+    pub fn clear_target_kv_cache_seq(
+        &mut self,
+        seq_id: Option<u32>,
+        p0: Option<u32>,
+        p1: Option<u32>,
+    ) -> Result<bool, crate::context::kv_cache::KvCacheConversionError> {
+        self.target.clear_kv_cache_seq(seq_id, p0, p1)
+    }
+
+    /// Removes a draft-context KV range.
+    ///
+    /// # Errors
+    ///
+    /// Returns a conversion error when an identifier or position exceeds
+    /// native `i32` bounds.
+    pub fn clear_draft_kv_cache_seq(
+        &mut self,
+        seq_id: Option<u32>,
+        p0: Option<u32>,
+        p1: Option<u32>,
+    ) -> Result<bool, crate::context::kv_cache::KvCacheConversionError> {
+        self.draft.clear_kv_cache_seq(seq_id, p0, p1)
+    }
+
+    /// Returns the target context's exact sequence-state byte count.
+    pub fn target_state_seq_get_size_ext(&mut self, seq_id: i32, flags: u32) -> usize {
+        self.target.state_seq_get_size_ext(seq_id, flags)
+    }
+
+    /// Copies target context sequence state with exact native flags.
+    pub fn target_state_seq_get_data_ext(
+        &mut self,
+        dst: &mut [u8],
+        seq_id: i32,
+        flags: u32,
+    ) -> usize {
+        self.target.state_seq_get_data_ext(dst, seq_id, flags)
+    }
+
+    /// Restores target context sequence state with exact native flags.
+    pub fn target_state_seq_set_data_ext(&mut self, src: &[u8], seq_id: i32, flags: u32) -> usize {
+        self.target.state_seq_set_data_ext(src, seq_id, flags)
+    }
+
+    /// Returns the draft context's exact sequence-state byte count.
+    pub fn draft_state_seq_get_size_ext(&mut self, seq_id: i32, flags: u32) -> usize {
+        self.draft.state_seq_get_size_ext(seq_id, flags)
+    }
+
+    /// Copies draft context sequence state with exact native flags.
+    pub fn draft_state_seq_get_data_ext(
+        &mut self,
+        dst: &mut [u8],
+        seq_id: i32,
+        flags: u32,
+    ) -> usize {
+        self.draft.state_seq_get_data_ext(dst, seq_id, flags)
+    }
+
+    /// Restores draft context sequence state with exact native flags.
+    pub fn draft_state_seq_set_data_ext(&mut self, src: &[u8], seq_id: i32, flags: u32) -> usize {
+        self.draft.state_seq_set_data_ext(src, seq_id, flags)
+    }
+
+    fn require_quiescent(&self) -> Result<(), MtpSessionError> {
+        if let Some((index, _)) = self
+            .pending_proposals
+            .iter()
+            .enumerate()
+            .find(|(_, proposal)| proposal.is_some())
+        {
+            return Err(MtpSessionError::ProposalPending {
+                seq_id: i32::try_from(index).unwrap_or(i32::MAX),
+            });
+        }
+        if !unsafe { llama_cpp_sys_4::mtp_session_is_quiescent(self.raw.as_ptr()) } {
+            return Err(MtpSessionError::State(SpeculativeStateError::NotQuiescent));
         }
         Ok(())
     }
@@ -479,15 +761,53 @@ impl MtpSession {
         }
         Ok(())
     }
+
+    fn sequence_index(&self, seq_id: i32) -> Result<usize, MtpSessionError> {
+        self.check_seq(seq_id)?;
+        usize::try_from(seq_id)
+            .map_err(|_| MtpSessionError::InvalidConfig("sequence id exceeds usize"))
+    }
 }
 
-impl Drop for MtpSession {
+fn validate_contexts(
+    target: &LlamaContext<'_>,
+    draft: &LlamaContext<'_>,
+    config: MtpSessionConfig,
+) -> Result<(), MtpSessionError> {
+    if target.context_type() != LlamaContextType::Default
+        || draft.context_type() != LlamaContextType::Mtp
+    {
+        return Err(MtpSessionError::IncompatibleContexts(
+            "target must be Default and draft must be Mtp",
+        ));
+    }
+    if target.n_seq_max() < config.n_seq || draft.n_seq_max() != config.n_seq {
+        return Err(MtpSessionError::IncompatibleContexts(
+            "target sequence capacity is too small or draft capacity differs from n_seq",
+        ));
+    }
+    let required_recurrent = u32::try_from(config.n_draft_max)
+        .map_err(|_| MtpSessionError::InvalidConfig("n_draft_max exceeds u32"))?;
+    if draft.n_rs_seq() < required_recurrent {
+        return Err(MtpSessionError::IncompatibleContexts(
+            "draft recurrent-state capacity is smaller than n_draft_max",
+        ));
+    }
+    if draft.model.n_embd_out() != target.model.n_embd() {
+        return Err(MtpSessionError::IncompatibleContexts(
+            "draft output width differs from target hidden width",
+        ));
+    }
+    Ok(())
+}
+
+impl Drop for MtpSession<'_, '_> {
     fn drop(&mut self) {
         unsafe { llama_cpp_sys_4::mtp_session_free(self.raw.as_ptr()) }
     }
 }
 
-impl std::fmt::Debug for MtpSession {
+impl std::fmt::Debug for MtpSession<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MtpSession")
             .field("config", &self.config)

--- a/llama-cpp-4/src/mtp.rs
+++ b/llama-cpp-4/src/mtp.rs
@@ -95,7 +95,10 @@ use crate::context::params::LlamaContextType;
 use crate::context::LlamaContext;
 use crate::llama_batch::LlamaBatch;
 use crate::speculative::MAX_SPECULATIVE_PROMPT_TOKENS;
-use crate::speculative::{capture_state, restore_state, validate_config, SpeculativeStateError};
+use crate::speculative::{
+    capture_state, restore_state, validate_config, validate_context_capacities,
+    SpeculativeContextCapacity, SpeculativeStateError,
+};
 use crate::token::LlamaToken;
 
 /// Errors raised by the MTP draft session.
@@ -786,13 +789,24 @@ fn validate_contexts(
             "target sequence capacity is too small or draft capacity differs from n_seq",
         ));
     }
-    let required_recurrent = u32::try_from(config.n_draft_max)
+    let required_draft = u32::try_from(config.n_draft_max)
         .map_err(|_| MtpSessionError::InvalidConfig("n_draft_max exceeds u32"))?;
-    if draft.n_rs_seq() < required_recurrent {
-        return Err(MtpSessionError::IncompatibleContexts(
-            "draft recurrent-state capacity is smaller than n_draft_max",
-        ));
-    }
+    validate_context_capacities(
+        SpeculativeContextCapacity {
+            batch: target.n_batch(),
+            micro_batch: target.n_ubatch(),
+            recurrent_slots: target.n_rs_seq(),
+            recurrent_or_hybrid: target.model.is_recurrent() || target.model.is_hybrid(),
+        },
+        SpeculativeContextCapacity {
+            batch: draft.n_batch(),
+            micro_batch: draft.n_ubatch(),
+            recurrent_slots: draft.n_rs_seq(),
+            recurrent_or_hybrid: draft.model.is_recurrent() || draft.model.is_hybrid(),
+        },
+        required_draft,
+    )
+    .map_err(MtpSessionError::IncompatibleContexts)?;
     if draft.model.n_embd_out() != target.model.n_embd() {
         return Err(MtpSessionError::IncompatibleContexts(
             "draft output width differs from target hidden width",

--- a/llama-cpp-4/src/prelude.rs
+++ b/llama-cpp-4/src/prelude.rs
@@ -153,7 +153,12 @@ pub use crate::context::params::{
     LlamaAttentionType, LlamaContextParams, LlamaContextType, LlamaFlashAttnType, LlamaPoolingType,
     ParamsCloneError, RopeScalingType,
 };
-pub use crate::context::{CapturedTensor, LlamaContext, MemoryBreakdownEntry, TensorCapture};
+pub use crate::context::{
+    CapturedTensor, CapturedTensorData, LlamaContext, MemoryBreakdownEntry, TensorAccess,
+    TensorBatchRow, TensorCallbackFailure, TensorCapture, TensorDataMut, TensorElementType,
+    TensorRowMapping, TensorSelector, TensorShape, TensorTransaction, TensorTransactionError,
+    TensorTransactionHandler, TensorTransactions, TensorWriteback, TransactionalTensorCapture,
+};
 pub use crate::llama_backend::LlamaBackend;
 pub use crate::llama_batch::{BatchAddError, LlamaBatch};
 pub use crate::model::params::kv_overrides::ParamOverrideValue;
@@ -162,6 +167,7 @@ pub use crate::model::{
     AddBos, LlamaBackendDevice, LlamaBackendDeviceType, LlamaChatMessage, LlamaModel, Special,
 };
 pub use crate::sampling::{LlamaSampler, LlamaSamplerParams};
+pub use crate::speculative::{SpeculativeStateError, MAX_SPECULATIVE_STATE_BYTES};
 pub use crate::token::data_array::LlamaTokenDataArray;
 pub use crate::token::detokenizer::{DetokenizeError, StreamDetokenizer};
 pub use crate::token::LlamaToken;

--- a/llama-cpp-4/src/speculative.rs
+++ b/llama-cpp-4/src/speculative.rs
@@ -165,6 +165,38 @@ pub(crate) fn validate_config(
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct SpeculativeContextCapacity {
+    pub(crate) batch: u32,
+    pub(crate) micro_batch: u32,
+    pub(crate) recurrent_slots: u32,
+    pub(crate) recurrent_or_hybrid: bool,
+}
+
+pub(crate) fn validate_context_capacities(
+    target: SpeculativeContextCapacity,
+    draft: SpeculativeContextCapacity,
+    maximum_draft_tokens: u32,
+) -> Result<(), &'static str> {
+    let required_rows = maximum_draft_tokens
+        .checked_add(1)
+        .ok_or("n_draft_max plus one exceeds u32")?;
+    if target.batch < required_rows || draft.batch < required_rows {
+        return Err("target or draft batch capacity is smaller than n_draft_max plus one");
+    }
+    if (target.recurrent_or_hybrid && target.micro_batch < required_rows)
+        || (draft.recurrent_or_hybrid && draft.micro_batch < required_rows)
+    {
+        return Err("recurrent micro-batch capacity is smaller than n_draft_max plus one");
+    }
+    if (target.recurrent_or_hybrid && target.recurrent_slots < maximum_draft_tokens)
+        || (draft.recurrent_or_hybrid && draft.recurrent_slots < maximum_draft_tokens)
+    {
+        return Err("recurrent context capacity is smaller than n_draft_max");
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -198,5 +230,52 @@ mod tests {
             .checked_mul(std::mem::size_of::<i32>())
             .unwrap();
         assert!(maximum_prompt_bytes < MAX_SPECULATIVE_STATE_BYTES);
+    }
+
+    #[test]
+    fn speculative_decode_capacity_is_checked_before_native_allocation() {
+        let transformer = SpeculativeContextCapacity {
+            batch: 4,
+            micro_batch: 1,
+            recurrent_slots: 0,
+            recurrent_or_hybrid: false,
+        };
+        assert!(validate_context_capacities(transformer, transformer, 3).is_ok());
+        assert!(validate_context_capacities(
+            SpeculativeContextCapacity {
+                batch: 3,
+                ..transformer
+            },
+            transformer,
+            3,
+        )
+        .is_err());
+
+        let recurrent = SpeculativeContextCapacity {
+            batch: 4,
+            micro_batch: 4,
+            recurrent_slots: 3,
+            recurrent_or_hybrid: true,
+        };
+        assert!(validate_context_capacities(recurrent, recurrent, 3).is_ok());
+        assert!(validate_context_capacities(
+            SpeculativeContextCapacity {
+                micro_batch: 3,
+                ..recurrent
+            },
+            recurrent,
+            3,
+        )
+        .is_err());
+        assert!(validate_context_capacities(
+            SpeculativeContextCapacity {
+                recurrent_slots: 2,
+                ..recurrent
+            },
+            recurrent,
+            3,
+        )
+        .is_err());
+        assert!(validate_context_capacities(transformer, transformer, u32::MAX).is_err());
     }
 }

--- a/llama-cpp-4/src/speculative.rs
+++ b/llama-cpp-4/src/speculative.rs
@@ -1,0 +1,202 @@
+//! Shared exact-state contracts for speculative draft sessions.
+
+use std::ptr::NonNull;
+
+/// Maximum speculative continuation bytes copied through the safe API.
+pub const MAX_SPECULATIVE_STATE_BYTES: usize = 64 * 1024 * 1024;
+/// Maximum concurrent sequence slots allocated by one speculative session.
+pub const MAX_SPECULATIVE_SEQUENCES: u32 = 4_096;
+/// Maximum tokens requested from one speculative draft boundary.
+pub const MAX_SPECULATIVE_DRAFT_TOKENS: i32 = 4_096;
+/// Maximum prompt tokens copied into one speculative session.
+pub const MAX_SPECULATIVE_PROMPT_TOKENS: usize = 1_048_576;
+
+/// Failure while capturing or restoring versioned speculative state.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum SpeculativeStateError {
+    /// A required native session or output pointer was null.
+    #[error("speculative state operation received a null native value")]
+    Null,
+    /// The sequence id is outside the configured session range.
+    #[error("speculative state sequence id is outside the configured range")]
+    BadSequence,
+    /// A draft proposal has not yet been completed with `accept`.
+    #[error("speculative state is available only at a quiescent boundary")]
+    NotQuiescent,
+    /// Native state changed size between the size and copy calls.
+    #[error("speculative state size changed from {expected} to {actual} bytes")]
+    SizeChanged {
+        /// Size returned by the initial query.
+        expected: usize,
+        /// Size required or written by the copy call.
+        actual: usize,
+    },
+    /// Native reported that the supplied buffer was too small without a size.
+    #[error("the speculative state buffer was too small")]
+    BufferTooSmall,
+    /// The active native implementation did not expose complete state.
+    #[error("the active speculative implementation did not expose complete state")]
+    Unavailable,
+    /// The supplied state failed its exact version/configuration checks.
+    #[error("speculative state is invalid for this session")]
+    Invalid,
+    /// Native state size arithmetic overflowed.
+    #[error("speculative state size overflowed")]
+    Overflow,
+    /// A C++ exception was contained by the speculative-state shim.
+    #[error("the native speculative-state operation raised an exception")]
+    Exception,
+    /// State exceeded the safe allocation/input bound.
+    #[error("speculative state is {size} bytes, exceeding the {maximum}-byte bound")]
+    Excessive {
+        /// Requested or supplied byte count.
+        size: usize,
+        /// Inclusive safe bound.
+        maximum: usize,
+    },
+    /// Native returned a status unknown to this binding revision.
+    #[error("unknown speculative state status {0}")]
+    Unknown(u32),
+}
+
+pub(crate) fn capture_state(
+    raw: NonNull<llama_cpp_sys_4::mtp_session>,
+    seq_id: i32,
+) -> Result<Vec<u8>, SpeculativeStateError> {
+    let mut size = 0_usize;
+    // SAFETY: `raw` is owned by the calling safe session and `size` is a live
+    // output for the duration of the synchronous call.
+    let status =
+        unsafe { llama_cpp_sys_4::mtp_session_state_size(raw.as_ptr(), seq_id, &raw mut size) };
+    status_result(status)?;
+    validate_size(size)?;
+
+    let mut state = vec![0_u8; size];
+    let mut written = 0_usize;
+    // SAFETY: the vector has exactly `size` writable bytes and the session
+    // remains exclusively borrowed by the caller.
+    let status = unsafe {
+        llama_cpp_sys_4::mtp_session_state_get(
+            raw.as_ptr(),
+            seq_id,
+            state.as_mut_ptr(),
+            state.len(),
+            &raw mut written,
+        )
+    };
+    if status == llama_cpp_sys_4::MTP_STATE_STATUS_BUFFER_SMALL {
+        return Err(SpeculativeStateError::SizeChanged {
+            expected: size,
+            actual: written,
+        });
+    }
+    status_result(status)?;
+    if written != size {
+        return Err(SpeculativeStateError::SizeChanged {
+            expected: size,
+            actual: written,
+        });
+    }
+    Ok(state)
+}
+
+pub(crate) fn restore_state(
+    raw: NonNull<llama_cpp_sys_4::mtp_session>,
+    seq_id: i32,
+    state: &[u8],
+) -> Result<(), SpeculativeStateError> {
+    validate_size(state.len())?;
+    if state.is_empty() {
+        return Err(SpeculativeStateError::Invalid);
+    }
+    // SAFETY: `state` remains live and immutable for the synchronous call; the
+    // owning safe session provides exclusive native access.
+    let status = unsafe {
+        llama_cpp_sys_4::mtp_session_state_set(raw.as_ptr(), seq_id, state.as_ptr(), state.len())
+    };
+    status_result(status)
+}
+
+fn validate_size(size: usize) -> Result<(), SpeculativeStateError> {
+    if size > MAX_SPECULATIVE_STATE_BYTES {
+        return Err(SpeculativeStateError::Excessive {
+            size,
+            maximum: MAX_SPECULATIVE_STATE_BYTES,
+        });
+    }
+    Ok(())
+}
+
+fn status_result(status: llama_cpp_sys_4::mtp_state_status) -> Result<(), SpeculativeStateError> {
+    match status {
+        llama_cpp_sys_4::MTP_STATE_STATUS_OK => Ok(()),
+        llama_cpp_sys_4::MTP_STATE_STATUS_NULL => Err(SpeculativeStateError::Null),
+        llama_cpp_sys_4::MTP_STATE_STATUS_BAD_SEQUENCE => Err(SpeculativeStateError::BadSequence),
+        llama_cpp_sys_4::MTP_STATE_STATUS_NOT_QUIESCENT => Err(SpeculativeStateError::NotQuiescent),
+        llama_cpp_sys_4::MTP_STATE_STATUS_BUFFER_SMALL => {
+            Err(SpeculativeStateError::BufferTooSmall)
+        }
+        llama_cpp_sys_4::MTP_STATE_STATUS_UNAVAILABLE => Err(SpeculativeStateError::Unavailable),
+        llama_cpp_sys_4::MTP_STATE_STATUS_INVALID => Err(SpeculativeStateError::Invalid),
+        llama_cpp_sys_4::MTP_STATE_STATUS_OVERFLOW => Err(SpeculativeStateError::Overflow),
+        llama_cpp_sys_4::MTP_STATE_STATUS_EXCEPTION => Err(SpeculativeStateError::Exception),
+        unknown => Err(SpeculativeStateError::Unknown(unknown)),
+    }
+}
+
+pub(crate) fn validate_config(
+    n_seq: u32,
+    n_draft_max: i32,
+    n_min: i32,
+    p_min: f32,
+) -> Result<(), &'static str> {
+    if n_seq == 0 || n_seq > MAX_SPECULATIVE_SEQUENCES {
+        return Err("n_seq is outside the supported bound");
+    }
+    if !(1..=MAX_SPECULATIVE_DRAFT_TOKENS).contains(&n_draft_max) {
+        return Err("n_draft_max is outside the supported bound");
+    }
+    if n_min < 0 || n_min > n_draft_max {
+        return Err("n_min must be between zero and n_draft_max");
+    }
+    if !p_min.is_finite() || !(0.0..=1.0).contains(&p_min) {
+        return Err("p_min must be finite and between zero and one");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_state_is_bounded_before_native_access() {
+        assert!(validate_size(MAX_SPECULATIVE_STATE_BYTES).is_ok());
+        assert_eq!(
+            validate_size(MAX_SPECULATIVE_STATE_BYTES + 1),
+            Err(SpeculativeStateError::Excessive {
+                size: MAX_SPECULATIVE_STATE_BYTES + 1,
+                maximum: MAX_SPECULATIVE_STATE_BYTES,
+            })
+        );
+    }
+
+    #[test]
+    fn speculative_configuration_is_bounded_before_allocation() {
+        assert!(validate_config(1, 4, 0, 0.0).is_ok());
+        assert!(validate_config(0, 4, 0, 0.0).is_err());
+        assert!(validate_config(MAX_SPECULATIVE_SEQUENCES + 1, 4, 0, 0.0).is_err());
+        assert!(validate_config(1, MAX_SPECULATIVE_DRAFT_TOKENS + 1, 0, 0.0).is_err());
+        assert!(validate_config(1, 4, 5, 0.0).is_err());
+        assert!(validate_config(1, 4, 0, f32::NAN).is_err());
+        assert!(validate_config(1, 4, 0, 1.1).is_err());
+    }
+
+    #[test]
+    fn prompt_and_state_bounds_are_consistent() {
+        let maximum_prompt_bytes = MAX_SPECULATIVE_PROMPT_TOKENS
+            .checked_mul(std::mem::size_of::<i32>())
+            .unwrap();
+        assert!(maximum_prompt_bytes < MAX_SPECULATIVE_STATE_BYTES);
+    }
+}

--- a/llama-cpp-4/tests/test_integration.rs
+++ b/llama-cpp-4/tests/test_integration.rs
@@ -285,10 +285,12 @@ fn integration_tensor_capture_last_layer() {
     let last_layer = (model.n_layer() - 1) as usize;
     let mut capture = TensorCapture::for_layers(&[last_layer]);
 
-    let ctx_params = LlamaContextParams::default()
-        .with_n_ctx(NonZeroU32::new(64))
-        .with_n_batch(64)
-        .with_tensor_capture(&mut capture);
+    let ctx_params = unsafe {
+        LlamaContextParams::default()
+            .with_n_ctx(NonZeroU32::new(64))
+            .with_n_batch(64)
+            .with_tensor_capture(&mut capture)
+    };
     let mut ctx = model.new_context(backend(), ctx_params).unwrap();
 
     let tokens = model.str_to_token("test", AddBos::Always).unwrap();

--- a/llama-cpp-4/tests/test_prelude.rs
+++ b/llama-cpp-4/tests/test_prelude.rs
@@ -7,7 +7,9 @@ fn prelude_core_types_are_in_scope() {
     fn assert_send<T: Send>() {}
     assert_send::<LlamaBackend>();
     assert_send::<LlamaModel>();
-    assert_send::<LlamaContextParams>();
+    // Context parameters may own callback and sampler state whose native
+    // pointers are deliberately confined to the constructing thread.
+    let _ = LlamaContextParams::default();
     assert_send::<TensorCapture>();
 }
 

--- a/llama-cpp-sys-4/README.md
+++ b/llama-cpp-sys-4/README.md
@@ -6,7 +6,7 @@
 Raw `bindgen`-generated bindings to [llama.cpp](https://github.com/ggml-org/llama.cpp),
 plus the C/C++ build logic that compiles the library.
 
-**llama.cpp version:** `99f3dc3 (b9982)` · **Crate version:** 0.4.2
+**llama.cpp revision:** `f87067841bac583bc089a225382248d857791ca8` · **Crate version:** 0.4.2
 
 Unless you need access to a symbol not yet exposed by [`llama-cpp-4`](../llama-cpp-4/),
 use that crate instead — it provides a safe API over these raw bindings.
@@ -40,16 +40,23 @@ use llama_cpp_4::prelude::*;
 | `native` | `-march=native` — tune for the build machine's CPU |
 | `rpc` | Remote compute backend |
 | `dynamic-link` | Link against a pre-installed shared `libllama` instead of building from source |
-| `prebuilt` | Download precompiled libs from GitHub releases (see below) |
+| `prebuilt` | Request a compatible precompiled build when one can be verified (see below) |
 
 ---
 
 ## Prebuilt libraries
 
-Skip the CMake compile by enabling `prebuilt` or setting `LLAMA_PREBUILT_DIR`:
+The exact speculative-state, decode-lifecycle, and fail-closed EAGLE-3 process
+patches require native libraries built from the same patched source. Existing
+0.4.2 archives do not carry a patch-identity envelope, so `prebuilt` currently
+emits a warning and uses the verified source build. `LLAMA_PREBUILT_DIR` fails
+closed while those patches are active rather than mixing patched headers with
+unverifiable native objects.
+
+Once release assets carry an exact patch identity, the intended interface is:
 
 ```bash
-# Automatic download + cache (falls back to local compile if no release asset)
+# Automatic download + cache, when a compatible release asset is available
 cargo build -p llama-cpp-sys-4 --features prebuilt
 
 # Prefetch manually, then build
@@ -96,7 +103,7 @@ cargo build -p llama-cpp-sys-4 --features mpi
 
 - `clang` — required by `bindgen` to parse the C++ headers
 - A C++17 compiler (GCC 9+, Clang 10+, MSVC 2019+)
-- `cmake` is **not** required — the build is driven entirely by `build.rs`
+- `cmake` and a supported CMake generator (Ninja is preferred)
 
 ### Regenerating bindings
 

--- a/llama-cpp-sys-4/build.rs
+++ b/llama-cpp-sys-4/build.rs
@@ -17,8 +17,45 @@ macro_rules! debug_log {
 }
 
 fn get_cargo_target_dir() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
-    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR")?);
     let profile = std::env::var("PROFILE")?;
+
+    // Cargo includes the active target/profile directory in the build
+    // script's runtime-library search path. Prefer that authoritative path:
+    // with unstable `build.build-dir`, OUT_DIR intentionally lives somewhere
+    // else and cannot identify where Cargo will look for shared libraries
+    // while running tests and binaries.
+    let runtime_path_variables: &[&str] = if cfg!(target_os = "windows") {
+        &["PATH"]
+    } else if cfg!(target_os = "macos") {
+        &["DYLD_FALLBACK_LIBRARY_PATH", "DYLD_LIBRARY_PATH"]
+    } else {
+        &["LD_LIBRARY_PATH"]
+    };
+    for variable in runtime_path_variables {
+        let Some(paths) = std::env::var_os(variable) else {
+            continue;
+        };
+        for path in std::env::split_paths(&paths) {
+            if path
+                .file_name()
+                .is_some_and(|name| name == std::ffi::OsStr::new(&profile))
+            {
+                return Ok(path);
+            }
+            if path.file_name().is_some_and(|name| name == "deps") {
+                if let Some(parent) = path.parent() {
+                    if parent
+                        .file_name()
+                        .is_some_and(|name| name == std::ffi::OsStr::new(&profile))
+                    {
+                        return Ok(parent.to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR")?);
     let mut target_dir = None;
     let mut sub_path = out_dir.as_path();
     while let Some(parent) = sub_path.parent() {
@@ -237,6 +274,58 @@ fn patch_target_path(dst: &Path, patch: &Patch<'_>) -> Result<PathBuf, String> {
     Ok(dst.join(rel))
 }
 
+fn patch_entries(patches_dir: &Path) -> Vec<PathBuf> {
+    if !patches_dir.is_dir() {
+        return Vec::new();
+    }
+    let mut entries: Vec<_> = std::fs::read_dir(patches_dir)
+        .expect("failed to read patches dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "patch")
+        })
+        .collect();
+    entries.sort();
+    entries
+}
+
+fn patches_match_new_side(patches_dir: &Path, dst: &Path) -> Result<bool, String> {
+    for patch_path in patch_entries(patches_dir) {
+        let patch_text = fs::read_to_string(&patch_path)
+            .map_err(|error| format!("failed to read patch {}: {error}", patch_path.display()))?;
+        let patches = Patch::from_multiple(&patch_text)
+            .map_err(|error| format!("failed to parse patch {}: {error}", patch_path.display()))?;
+
+        for patch in patches {
+            let file_path = patch_target_path(dst, &patch)?;
+            let creates_file = patch.old.path.as_ref() == "/dev/null";
+            let deletes_file = patch.new.path.as_ref() == "/dev/null";
+            let current = match fs::read_to_string(&file_path) {
+                Ok(contents) => contents,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound && deletes_file => {
+                    continue;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound && creates_file => {
+                    return Ok(false);
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "failed to read patched target {}: {error}",
+                        file_path.display()
+                    ));
+                }
+            };
+            let current_lines: Vec<&str> = current.lines().collect();
+            if !patch_matches_side(&current_lines, &patch, true) {
+                return Ok(false);
+            }
+        }
+    }
+    Ok(true)
+}
+
 fn apply_patches_via_rust(entries: &[PathBuf], dst: &Path) -> Result<(), String> {
     for patch_path in entries {
         println!(
@@ -347,16 +436,7 @@ fn apply_patches_via_cli(entries: &[PathBuf], dst: &Path) -> Result<(), String> 
 /// Uses the `patch -p1` command.
 /// Skips the patches directory entirely when it does not exist or is empty.
 fn apply_patches(patches_dir: &Path, dst: &Path) {
-    if !patches_dir.is_dir() {
-        return;
-    }
-    let mut entries: Vec<_> = std::fs::read_dir(patches_dir)
-        .expect("failed to read patches dir")
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| p.extension().map(|e| e == "patch").unwrap_or(false))
-        .collect();
-    entries.sort();
+    let entries = patch_entries(patches_dir);
     if entries.is_empty() {
         return;
     }
@@ -379,6 +459,48 @@ fn apply_patches(patches_dir: &Path, dst: &Path) {
              The patch may need rebasing against the current llama.cpp submodule commit."
         );
     }
+}
+
+fn stage_active_patches(patches_dir: &Path, staged_dir: &Path) -> bool {
+    if staged_dir.exists() {
+        std::fs::remove_dir_all(staged_dir).expect("failed to clear staged llama.cpp patches");
+    }
+    std::fs::create_dir_all(staged_dir).expect("failed to create staged llama.cpp patches");
+    let always_active = [
+        "0003-exact-speculative-state.patch",
+        "0004-exact-decode-lifecycle-hooks.patch",
+        "0005-fail-closed-eagle3-process.patch",
+    ];
+    for name in always_active {
+        let source = patches_dir.join(name);
+        assert!(
+            source.is_file(),
+            "required llama.cpp patch is absent: {}",
+            source.display()
+        );
+        std::fs::copy(&source, staged_dir.join(name))
+            .unwrap_or_else(|error| panic!("failed to stage {name}: {error}"));
+    }
+
+    if cfg!(feature = "q1") {
+        let name = "0001-q1-quantization.patch";
+        let source = patches_dir.join(name);
+        if source.exists() {
+            std::fs::copy(&source, staged_dir.join(name))
+                .unwrap_or_else(|error| panic!("failed to stage {name}: {error}"));
+        }
+    }
+
+    if cfg!(feature = "vulkan") {
+        let name = "0002-vulkan-spirv-headers-sdk.patch";
+        let source = patches_dir.join(name);
+        if source.exists() {
+            std::fs::copy(&source, staged_dir.join(name))
+                .unwrap_or_else(|error| panic!("failed to stage {name}: {error}"));
+        }
+    }
+
+    true
 }
 
 /// Return a string that uniquely identifies the current state of the llama.cpp
@@ -1223,6 +1345,7 @@ fn main() {
     debug_log!("CARGO_MANIFEST_DIR: {}", manifest_dir);
     debug_log!("TARGET_DIR: {}", target_dir.display());
     debug_log!("OUT_DIR: {}", out_dir.display());
+    debug_log!("LD_LIBRARY_PATH: {:?}", env::var_os("LD_LIBRARY_PATH"));
     debug_log!("BUILD_SHARED: {}", build_shared_libs);
 
     // ── Source copy with version tracking ────────────────────────────────────
@@ -1234,66 +1357,38 @@ fn main() {
     let sentinel = out_dir.join(".llama-src-version");
     let current_version = llama_src_version(&llama_src, &patches_dir);
     let stored_version = std::fs::read_to_string(&sentinel).unwrap_or_default();
-    let needs_copy = !llama_dst.exists() || stored_version.trim() != current_version.trim();
+    let staged_dir = out_dir.join("patches-active");
+    let staged_any = stage_active_patches(&patches_dir, &staged_dir);
+    let patches_applied = !staged_any
+        || patches_match_new_side(&staged_dir, &llama_dst).unwrap_or_else(|error| {
+            debug_log!(
+                "Failed to verify the staged patch postcondition for {}: {}",
+                llama_dst.display(),
+                error
+            );
+            false
+        });
+    let needs_copy =
+        !llama_dst.exists() || stored_version.trim() != current_version.trim() || !patches_applied;
     if needs_copy {
         if llama_dst.exists() {
-            debug_log!("Source version changed — removing stale OUT_DIR copy");
+            debug_log!(
+                "Source version or patch postcondition changed — removing stale OUT_DIR copy"
+            );
             std::fs::remove_dir_all(&llama_dst).ok();
         }
         debug_log!("Copy {} to {}", llama_src.display(), llama_dst.display());
         copy_folder(&llama_src, &llama_dst);
 
-        // Apply local patches (only those gated by active Cargo features).
-        let staged_dir = out_dir.join("patches-active");
-        if staged_dir.exists() {
-            std::fs::remove_dir_all(&staged_dir).expect("failed to clear staged llama.cpp patches");
-        }
-        std::fs::create_dir_all(&staged_dir).ok();
-        let mut staged_any = false;
-
-        let speculative_patch = patches_dir.join("0003-exact-speculative-state.patch");
-        if speculative_patch.exists() {
-            std::fs::copy(
-                &speculative_patch,
-                staged_dir.join("0003-exact-speculative-state.patch"),
-            )
-            .expect("failed to stage exact speculative state patch");
-            staged_any = true;
-        }
-
-        let lifecycle_patch = patches_dir.join("0004-exact-decode-lifecycle-hooks.patch");
-        if lifecycle_patch.exists() {
-            std::fs::copy(
-                &lifecycle_patch,
-                staged_dir.join("0004-exact-decode-lifecycle-hooks.patch"),
-            )
-            .expect("failed to stage exact decode lifecycle patch");
-            staged_any = true;
-        }
-
-        if cfg!(feature = "q1") {
-            let q1_patch = patches_dir.join("0001-q1-quantization.patch");
-            if q1_patch.exists() {
-                std::fs::copy(&q1_patch, staged_dir.join("0001-q1-quantization.patch"))
-                    .expect("failed to stage q1 patch");
-                staged_any = true;
-            }
-        }
-
-        if cfg!(feature = "vulkan") {
-            let spirv_patch = patches_dir.join("0002-vulkan-spirv-headers-sdk.patch");
-            if spirv_patch.exists() {
-                std::fs::copy(
-                    &spirv_patch,
-                    staged_dir.join("0002-vulkan-spirv-headers-sdk.patch"),
-                )
-                .expect("failed to stage vulkan SPIRV-Headers patch");
-                staged_any = true;
-            }
-        }
-
         if staged_any {
             apply_patches(&staged_dir, &llama_dst);
+            if !patches_match_new_side(&staged_dir, &llama_dst)
+                .unwrap_or_else(|error| panic!("failed to verify applied patches: {error}"))
+            {
+                panic!(
+                    "llama.cpp patch application completed without satisfying the staged postcondition"
+                );
+            }
         }
         std::fs::write(&sentinel, &current_version)
             .expect("failed to write source version sentinel");
@@ -1495,8 +1590,29 @@ fn main() {
     // Expected layout is flexible; files may be in <dir>, <dir>/lib,
     // <dir>/lib64, or <dir>/bin.
 
+    // A prebuilt archive is safe only when it contains the same patched
+    // native implementation as the headers and shim compiled in this build.
+    // Existing 0.4.2 archives do not carry a patch identity, so fail closed
+    // for explicit paths and make the convenience feature use the verified
+    // source build while exact patches are active.
+    let prebuilt_dir = if staged_any {
+        if let Ok(path) = env::var("LLAMA_PREBUILT_DIR") {
+            panic!(
+                "LLAMA_PREBUILT_DIR='{path}' cannot be verified against the active llama.cpp patches; use the source build"
+            );
+        }
+        if cfg!(feature = "prebuilt") {
+            println!(
+                "cargo:warning=The active llama.cpp patches have no prebuilt identity envelope; falling back to the verified source build"
+            );
+        }
+        None
+    } else {
+        resolve_prebuilt_directory(&target, build_shared_libs)
+    };
+
     // Try prebuilt path (explicit LLAMA_PREBUILT_DIR or `prebuilt` feature download).
-    if let Some(prebuilt_dir) = resolve_prebuilt_directory(&target, build_shared_libs) {
+    if let Some(prebuilt_dir) = prebuilt_dir {
         if prebuilt_dir.exists() {
             let use_shared_libs = env::var("LLAMA_PREBUILT_SHARED")
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("on"))
@@ -1718,15 +1834,16 @@ fn main() {
         config.define("CMAKE_DISABLE_FIND_PACKAGE_Git", "ON");
     }
 
-    // Build tools (including the mtmd library) only when the mtmd feature is
-    // requested.  Common is also required because the CMakeLists gate for
-    // tools is `if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TOOLS)`.
+    // The speculative-session shim calls llama.cpp's `common_speculative_*`
+    // implementation, which lives in llama-common. Build that library for
+    // every source configuration so downstream binaries cannot compile the
+    // shim and then fail to link its implementation. Tools (including mtmd)
+    // remain opt-in.
+    config.define("LLAMA_BUILD_COMMON", "ON");
     if cfg!(feature = "mtmd") {
         config.define("LLAMA_BUILD_TOOLS", "ON");
-        config.define("LLAMA_BUILD_COMMON", "ON");
     } else {
         config.define("LLAMA_BUILD_TOOLS", "OFF");
-        config.define("LLAMA_BUILD_COMMON", "OFF");
     }
 
     config.define(
@@ -2102,13 +2219,10 @@ fn main() {
     //     configure run was interrupted.  cmake --build would fail with "No
     //     such file or directory".
     //
-    //  2. CMakeCache.txt has GGML_NATIVE set to the wrong value: this happens
-    //     when build.rs is updated (e.g. the GGML_NATIVE=OFF fix) without
-    //     bumping the crate version, so Cargo reuses the same OUT_DIR and the
-    //     cmake crate skips configuration entirely — leaving the old ON value
-    //     in the cache and baking -mcpu=native into the library, which then
-    //     crashes with SIGILL on any chip that lacks the build host's ISA
-    //     extensions.
+    //  2. CMakeCache.txt contains an option that conflicts with this build.rs:
+    //     this happens when build.rs changes without a crate-version bump, so
+    //     Cargo reuses the shared directory and the cmake crate skips
+    //     configuration entirely.
     {
         let cmake_build_dir = cmake_out_dir.join("build");
         let cache = cmake_build_dir.join("CMakeCache.txt");
@@ -2136,7 +2250,11 @@ fn main() {
                 let native_mismatch =
                     (want_native && cached_native_off) || (!want_native && cached_native_on);
 
-                // 2b. GGML_CPU_ARM_ARCH in cache doesn't match what we intend
+                // 2b. llama-common supplies the implementation behind the
+                //     always-built speculative-session shim.
+                let common_mismatch = !cache_contents.contains("LLAMA_BUILD_COMMON:BOOL=ON");
+
+                // 2c. GGML_CPU_ARM_ARCH in cache doesn't match what we intend
                 //     to set (ARM non-native non-android builds).  Without an
                 //     explicit -march flag, Apple Clang silently enables
                 //     dotprod/i8mm for arm64-apple-macosx targets, producing
@@ -2159,7 +2277,7 @@ fn main() {
                     .unwrap_or("");
                 let arm_arch_mismatch = we_set_arm_arch && cached_arm_arch != "armv8-a";
 
-                // 2c. x86 ISA options: when !want_native on x86, we now
+                // 2d. x86 ISA options: when !want_native on x86, we now
                 //     force AVX/AVX2/FMA/F16C/BMI2 to OFF.  A stale cache
                 //     from a previous build (or from before this fix) may
                 //     still have them ON, causing SIGILL on older CPUs.
@@ -2179,7 +2297,7 @@ fn main() {
                     stale_options.iter().any(|opt| cache_contents.contains(opt))
                 };
 
-                // 2d. GGML_METAL mismatch: on macOS, llama.cpp defaults
+                // 2e. GGML_METAL mismatch: on macOS, llama.cpp defaults
                 //     GGML_METAL to ON, so a stale cache from a previous
                 //     `--features metal` build (or from the cmake default)
                 //     would keep Metal enabled even when the feature is off.
@@ -2189,7 +2307,7 @@ fn main() {
                     (enable_metal && cached_metal_off) || (!enable_metal && cached_metal_on)
                 };
 
-                // 2e. GGML_WEBGPU mismatch: stale cache may keep WebGPU ON/OFF
+                // 2f. GGML_WEBGPU mismatch: stale cache may keep WebGPU ON/OFF
                 //     after feature toggles.
                 let webgpu_mismatch = {
                     let cached_webgpu_on = cache_contents.contains("GGML_WEBGPU:BOOL=ON");
@@ -2198,7 +2316,7 @@ fn main() {
                         || (!cfg!(feature = "webgpu") && cached_webgpu_on)
                 };
 
-                // 2f. CMAKE_OSX_ARCHITECTURES mismatch: a stale cache from
+                // 2g. CMAKE_OSX_ARCHITECTURES mismatch: a stale cache from
                 //     a previous build (or from an environment-polluted cmake
                 //     run) may have the wrong architecture, producing x86_64
                 //     object code in an arm64 binary (or vice versa).
@@ -2223,6 +2341,7 @@ fn main() {
                 };
 
                 let mismatch = native_mismatch
+                    || common_mismatch
                     || arm_arch_mismatch
                     || x86_isa_mismatch
                     || metal_mismatch
@@ -2231,6 +2350,7 @@ fn main() {
                 if mismatch {
                     debug_log!(
                         "CMakeCache.txt is stale (GGML_NATIVE: cache={} want={}; \
+                         LLAMA_BUILD_COMMON mismatch={}; \
                          GGML_CPU_ARM_ARCH: cache={:?} want={}) — removing cache \
                          to force reconfiguration",
                         if cached_native_on {
@@ -2241,6 +2361,7 @@ fn main() {
                             "?"
                         },
                         desired_native_str,
+                        common_mismatch,
                         cached_arm_arch,
                         if we_set_arm_arch {
                             "armv8-a"

--- a/llama-cpp-sys-4/build.rs
+++ b/llama-cpp-sys-4/build.rs
@@ -388,6 +388,7 @@ fn apply_patches(patches_dir: &Path, dst: &Path) {
 /// 1. The commit hash from the submodule's git HEAD (most precise).
 /// 2. The mtime of `CMakeLists.txt` (fallback for non-git trees).
 fn llama_src_version(src: &Path, patches_dir: &Path) -> String {
+    const PATCH_STAGING_VERSION: &str = "2";
     let ph = patches_hash(patches_dir);
     // In a git submodule the `.git` entry is a *file* whose content is:
     //   gitdir: ../../.git/modules/llama-cpp-sys-4/llama.cpp
@@ -404,10 +405,10 @@ fn llama_src_version(src: &Path, patches_dir: &Path) -> String {
                         let ref_path = head.strip_prefix("ref:").map(str::trim).unwrap_or(head);
                         let commit_path = git_file.parent().unwrap().join(rel).join(ref_path);
                         if let Ok(hash) = std::fs::read_to_string(commit_path) {
-                            return format!("{}:{}", hash.trim(), ph);
+                            return format!("{}:{}:{PATCH_STAGING_VERSION}", hash.trim(), ph);
                         }
                     }
-                    return format!("{}:{}", head, ph);
+                    return format!("{}:{}:{PATCH_STAGING_VERSION}", head, ph);
                 }
             }
         }
@@ -420,7 +421,11 @@ fn llama_src_version(src: &Path, patches_dir: &Path) -> String {
         .map(|t| format!("{t:?}"))
         .unwrap_or_else(|_| "unknown".to_owned());
     // Mix in patch contents so that updating patches forces a re-copy+re-patch.
-    format!("{}:{}", base, patches_hash(patches_dir))
+    format!(
+        "{}:{}:{PATCH_STAGING_VERSION}",
+        base,
+        patches_hash(patches_dir)
+    )
 }
 
 /// Copy a directory tree.  This runs on the *host*, so cfg!(unix/windows) is correct here.
@@ -1240,8 +1245,31 @@ fn main() {
 
         // Apply local patches (only those gated by active Cargo features).
         let staged_dir = out_dir.join("patches-active");
+        if staged_dir.exists() {
+            std::fs::remove_dir_all(&staged_dir).expect("failed to clear staged llama.cpp patches");
+        }
         std::fs::create_dir_all(&staged_dir).ok();
         let mut staged_any = false;
+
+        let speculative_patch = patches_dir.join("0003-exact-speculative-state.patch");
+        if speculative_patch.exists() {
+            std::fs::copy(
+                &speculative_patch,
+                staged_dir.join("0003-exact-speculative-state.patch"),
+            )
+            .expect("failed to stage exact speculative state patch");
+            staged_any = true;
+        }
+
+        let lifecycle_patch = patches_dir.join("0004-exact-decode-lifecycle-hooks.patch");
+        if lifecycle_patch.exists() {
+            std::fs::copy(
+                &lifecycle_patch,
+                staged_dir.join("0004-exact-decode-lifecycle-hooks.patch"),
+            )
+            .expect("failed to stage exact decode lifecycle patch");
+            staged_any = true;
+        }
 
         if cfg!(feature = "q1") {
             let q1_patch = patches_dir.join("0001-q1-quantization.patch");
@@ -1360,6 +1388,7 @@ fn main() {
         .allowlist_function("mtp_session_.*")
         .allowlist_type("mtp_session")
         .allowlist_type("mtp_session_config")
+        .allowlist_type("mtp_state_status")
         .allowlist_function("llama_memory_breakdown_collect")
         .allowlist_type("llama_memory_breakdown_entry")
         .allowlist_function("common_device_memory_collect")
@@ -1370,6 +1399,7 @@ fn main() {
         // constants are emitted.
         .allowlist_type("mtp_spec_type")
         .allowlist_item("MTP_SPEC_TYPE_.*")
+        .allowlist_item("MTP_STATE_STATUS_.*")
         .opaque_type("mtp_session")
         .allowlist_function("common_token_to_piece")
         .allowlist_function("common_tokenize")
@@ -2376,6 +2406,14 @@ fn main() {
             // with EEXIST because the directory entry is occupied. Using symlink_metadata()
             // detects both regular files and symlinks (broken or valid).
             let force_hard_link = |src: &Path, dst: &Path| {
+                if let Some(parent) = dst.parent() {
+                    std::fs::create_dir_all(parent).unwrap_or_else(|error| {
+                        panic!(
+                            "Failed to create shared-library destination {}: {error}",
+                            parent.display()
+                        )
+                    });
+                }
                 if dst.symlink_metadata().is_ok() {
                     let _ = std::fs::remove_file(dst);
                 }

--- a/llama-cpp-sys-4/mtp_shim/mtp_shim.cpp
+++ b/llama-cpp-sys-4/mtp_shim/mtp_shim.cpp
@@ -3,6 +3,11 @@
 #include "common.h"
 #include "speculative.h"
 
+#include <cstring>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <utility>
 #include <vector>
 
 struct mtp_session {
@@ -15,52 +20,165 @@ struct mtp_session {
     // Per-seq result buffer the draft() call writes into.
     std::vector<llama_tokens> results;
 
+    // True between a successful nonempty draft and its matching accept.
+    std::vector<bool> pending_proposals;
+
     uint32_t n_seq       = 0;
     int32_t  n_draft_max = 0;
     int32_t  n_min       = 0;
     float    p_min       = 0.0f;
+    int32_t  spec_type   = MTP_SPEC_TYPE_MTP;
 };
+
+namespace {
+
+constexpr uint8_t MTP_STATE_MAGIC[8] = { 'L', 'L', 'S', 'P', 'E', 'C', '1', 0 };
+constexpr uint32_t MTP_STATE_VERSION = 1;
+constexpr size_t MTP_STATE_HEADER_SIZE = 8 + 9 * sizeof(uint32_t);
+constexpr size_t MTP_MAX_PROMPT_TOKENS = 1U << 20;
+constexpr size_t MTP_MAX_STATE_BYTES = 64U * 1024U * 1024U;
+
+bool mtp_session_valid_seq(const mtp_session * s, int32_t seq_id) {
+    return s != nullptr && seq_id >= 0 && (uint32_t) seq_id < s->n_seq;
+}
+
+bool mtp_session_quiescent(const mtp_session * s) {
+    if (s == nullptr) {
+        return false;
+    }
+    for (bool pending : s->pending_proposals) {
+        if (pending) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void append_u32(std::vector<uint8_t> & out, uint32_t value) {
+    out.push_back((uint8_t) (value & 0xff));
+    out.push_back((uint8_t) ((value >> 8) & 0xff));
+    out.push_back((uint8_t) ((value >> 16) & 0xff));
+    out.push_back((uint8_t) ((value >> 24) & 0xff));
+}
+
+bool read_u32(const uint8_t * data, size_t size, size_t & offset, uint32_t & value) {
+    if (offset > size || size - offset < sizeof(uint32_t)) {
+        return false;
+    }
+    value = (uint32_t) data[offset]
+          | (uint32_t) data[offset + 1] << 8
+          | (uint32_t) data[offset + 2] << 16
+          | (uint32_t) data[offset + 3] << 24;
+    offset += sizeof(uint32_t);
+    return true;
+}
+
+mtp_state_status build_state(
+        const mtp_session * s,
+        int32_t             seq_id,
+        std::vector<uint8_t> & out) {
+    if (s == nullptr) {
+        return MTP_STATE_STATUS_NULL;
+    }
+    if (!mtp_session_valid_seq(s, seq_id)) {
+        return MTP_STATE_STATUS_BAD_SEQUENCE;
+    }
+    if (!mtp_session_quiescent(s)) {
+        return MTP_STATE_STATUS_NOT_QUIESCENT;
+    }
+
+    std::vector<uint8_t> implementation;
+    if (!common_speculative_get_state(s->spec.get(), seq_id, implementation)) {
+        return MTP_STATE_STATUS_UNAVAILABLE;
+    }
+    const auto & prompt = s->prompts[seq_id];
+    if (prompt.size() > std::numeric_limits<uint32_t>::max() ||
+            implementation.size() > std::numeric_limits<uint32_t>::max()) {
+        return MTP_STATE_STATUS_OVERFLOW;
+    }
+    const size_t prompt_bytes = prompt.size() * sizeof(uint32_t);
+    if (prompt_bytes / sizeof(uint32_t) != prompt.size() ||
+            MTP_STATE_HEADER_SIZE > std::numeric_limits<size_t>::max() - prompt_bytes ||
+            MTP_STATE_HEADER_SIZE + prompt_bytes >
+                    std::numeric_limits<size_t>::max() - implementation.size()) {
+        return MTP_STATE_STATUS_OVERFLOW;
+    }
+    const size_t total_size = MTP_STATE_HEADER_SIZE + prompt_bytes + implementation.size();
+    if (total_size > MTP_MAX_STATE_BYTES) {
+        return MTP_STATE_STATUS_OVERFLOW;
+    }
+
+    out.clear();
+    out.reserve(total_size);
+    out.insert(out.end(), std::begin(MTP_STATE_MAGIC), std::end(MTP_STATE_MAGIC));
+    append_u32(out, MTP_STATE_VERSION);
+    append_u32(out, (uint32_t) s->spec_type);
+    append_u32(out, s->n_seq);
+    append_u32(out, (uint32_t) s->n_draft_max);
+    append_u32(out, (uint32_t) s->n_min);
+    uint32_t p_min_bits = 0;
+    static_assert(sizeof(p_min_bits) == sizeof(s->p_min));
+    std::memcpy(&p_min_bits, &s->p_min, sizeof(p_min_bits));
+    append_u32(out, p_min_bits);
+    append_u32(out, (uint32_t) seq_id);
+    append_u32(out, (uint32_t) prompt.size());
+    append_u32(out, (uint32_t) implementation.size());
+    for (llama_token token : prompt) {
+        append_u32(out, (uint32_t) token);
+    }
+    out.insert(out.end(), implementation.begin(), implementation.end());
+    return MTP_STATE_STATUS_OK;
+}
+
+} // namespace
 
 extern "C" mtp_session * mtp_session_new(
         llama_context *             ctx_tgt,
         llama_context *             ctx_dft,
         const mtp_session_config * config) {
-    if (ctx_tgt == nullptr || ctx_dft == nullptr || config == nullptr) {
+    try {
+        if (ctx_tgt == nullptr || ctx_dft == nullptr || config == nullptr) {
+            return nullptr;
+        }
+        if (config->n_seq == 0 || config->n_draft_max <= 0) {
+            return nullptr;
+        }
+
+        common_speculative_type spec_type;
+        switch (config->spec_type) {
+            case MTP_SPEC_TYPE_MTP:    spec_type = COMMON_SPECULATIVE_TYPE_DRAFT_MTP;    break;
+            case MTP_SPEC_TYPE_EAGLE3: spec_type = COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3; break;
+            default:                   return nullptr; // unknown spec_type
+        }
+
+        common_params_speculative sparams;
+        sparams.types         = { spec_type };
+        sparams.draft.ctx_tgt = ctx_tgt;
+        sparams.draft.ctx_dft = ctx_dft;
+        sparams.draft.n_max   = config->n_draft_max;
+        sparams.draft.n_min   = config->n_min;
+        sparams.draft.p_min   = config->p_min;
+
+        common_speculative * raw = common_speculative_init(sparams, config->n_seq);
+        if (raw == nullptr) {
+            return nullptr;
+        }
+
+        common_speculative_ptr spec(raw);
+        auto s = std::make_unique<mtp_session>();
+        s->spec = std::move(spec);
+        s->prompts.resize(config->n_seq);
+        s->results.resize(config->n_seq);
+        s->pending_proposals.resize(config->n_seq, false);
+        s->n_seq       = config->n_seq;
+        s->n_draft_max = config->n_draft_max;
+        s->n_min       = config->n_min;
+        s->p_min       = config->p_min;
+        s->spec_type   = config->spec_type;
+        return s.release();
+    } catch (...) {
         return nullptr;
     }
-    if (config->n_seq == 0 || config->n_draft_max <= 0) {
-        return nullptr;
-    }
-
-    common_speculative_type spec_type;
-    switch (config->spec_type) {
-        case MTP_SPEC_TYPE_MTP:    spec_type = COMMON_SPECULATIVE_TYPE_DRAFT_MTP;    break;
-        case MTP_SPEC_TYPE_EAGLE3: spec_type = COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3; break;
-        default:                   return nullptr; // unknown spec_type
-    }
-
-    common_params_speculative sparams;
-    sparams.types         = { spec_type };
-    sparams.draft.ctx_tgt = ctx_tgt;
-    sparams.draft.ctx_dft = ctx_dft;
-    sparams.draft.n_max   = config->n_draft_max;
-    sparams.draft.n_min   = config->n_min;
-    sparams.draft.p_min   = config->p_min;
-
-    common_speculative * raw = common_speculative_init(sparams, config->n_seq);
-    if (raw == nullptr) {
-        return nullptr;
-    }
-
-    auto * s = new mtp_session;
-    s->spec.reset(raw);
-    s->prompts.resize(config->n_seq);
-    s->results.resize(config->n_seq);
-    s->n_seq       = config->n_seq;
-    s->n_draft_max = config->n_draft_max;
-    s->n_min       = config->n_min;
-    s->p_min       = config->p_min;
-    return s;
 }
 
 extern "C" void mtp_session_free(mtp_session * s) {
@@ -71,28 +189,47 @@ extern "C" bool mtp_session_need_embd(const mtp_session * s) {
     if (s == nullptr) {
         return false;
     }
-    return common_speculative_need_embd(s->spec.get());
+    try {
+        return common_speculative_need_embd(s->spec.get());
+    } catch (...) {
+        return false;
+    }
 }
 
 extern "C" bool mtp_session_need_embd_pre_norm(const mtp_session * s) {
     if (s == nullptr) {
         return false;
     }
-    return common_speculative_need_embd_nextn(s->spec.get());
+    try {
+        return common_speculative_need_embd_nextn(s->spec.get());
+    } catch (...) {
+        return false;
+    }
 }
 
-extern "C" void mtp_session_begin(
+extern "C" bool mtp_session_begin(
         mtp_session *       s,
         int32_t             seq_id,
         const llama_token * prompt,
         size_t              n_prompt) {
-    if (s == nullptr || seq_id < 0 || (uint32_t) seq_id >= s->n_seq) {
-        return;
+    if (!mtp_session_valid_seq(s, seq_id) || s->pending_proposals[seq_id] ||
+            n_prompt > MTP_MAX_PROMPT_TOKENS ||
+            (n_prompt > 0 && prompt == nullptr)) {
+        return false;
     }
 
-    auto & p = s->prompts[seq_id];
-    p.assign(prompt, prompt + n_prompt);
-    common_speculative_begin(s->spec.get(), seq_id, p);
+    try {
+        auto & p = s->prompts[seq_id];
+        if (n_prompt == 0) {
+            p.clear();
+        } else {
+            p.assign(prompt, prompt + n_prompt);
+        }
+        common_speculative_begin(s->spec.get(), seq_id, p);
+        return true;
+    } catch (...) {
+        return false;
+    }
 }
 
 extern "C" bool mtp_session_process(
@@ -101,10 +238,14 @@ extern "C" bool mtp_session_process(
     if (s == nullptr || batch == nullptr) {
         return false;
     }
-    return common_speculative_process(s->spec.get(), *batch);
+    try {
+        return common_speculative_process(s->spec.get(), *batch);
+    } catch (...) {
+        return false;
+    }
 }
 
-extern "C" void mtp_session_draft(
+extern "C" bool mtp_session_draft(
         mtp_session * s,
         int32_t       seq_id,
         llama_pos     n_past,
@@ -113,52 +254,237 @@ extern "C" void mtp_session_draft(
         int32_t *     out_n_tokens) {
     if (s == nullptr || out_tokens == nullptr || out_n_tokens == nullptr) {
         if (out_n_tokens) *out_n_tokens = 0;
-        return;
+        return false;
     }
 
     const int32_t cap = *out_n_tokens;
     *out_n_tokens = 0;
 
     if (seq_id < 0 || (uint32_t) seq_id >= s->n_seq) {
-        return;
+        return false;
+    }
+    if (s->pending_proposals[seq_id] || cap < s->n_draft_max) {
+        return false;
     }
 
-    auto & dp = common_speculative_get_draft_params(s->spec.get(), seq_id);
-    auto & result = s->results[seq_id];
-    result.clear();
+    try {
+        auto & dp = common_speculative_get_draft_params(s->spec.get(), seq_id);
+        auto & result = s->results[seq_id];
+        result.clear();
 
-    dp.drafting = true;
-    dp.n_max    = s->n_draft_max;
-    dp.n_past   = n_past;
-    dp.id_last  = id_last;
-    dp.prompt   = &s->prompts[seq_id];
-    dp.result   = &result;
+        dp.drafting = true;
+        dp.n_max    = s->n_draft_max;
+        dp.n_past   = n_past;
+        dp.id_last  = id_last;
+        dp.prompt   = &s->prompts[seq_id];
+        dp.result   = &result;
 
-    common_speculative_draft(s->spec.get());
+        common_speculative_draft(s->spec.get());
 
-    const int32_t n = (int32_t) result.size();
-    const int32_t to_copy = n < cap ? n : cap;
-    for (int32_t i = 0; i < to_copy; ++i) {
-        out_tokens[i] = result[i];
+        const int32_t n = (int32_t) result.size();
+        const int32_t to_copy = n < cap ? n : cap;
+        for (int32_t i = 0; i < to_copy; ++i) {
+            out_tokens[i] = result[i];
+        }
+        *out_n_tokens = to_copy;
+        s->pending_proposals[seq_id] = to_copy > 0;
+        return true;
+    } catch (...) {
+        *out_n_tokens = 0;
+        return false;
     }
-    *out_n_tokens = to_copy;
 }
 
-extern "C" void mtp_session_accept(
+extern "C" bool mtp_session_accept(
         mtp_session * s,
         int32_t       seq_id,
         uint16_t      n_accepted) {
-    if (s == nullptr || seq_id < 0 || (uint32_t) seq_id >= s->n_seq) {
-        return;
+    if (!mtp_session_valid_seq(s, seq_id) || !s->pending_proposals[seq_id] ||
+            n_accepted > s->results[seq_id].size()) {
+        return false;
     }
-    common_speculative_accept(s->spec.get(), seq_id, n_accepted);
+    try {
+        common_speculative_accept(s->spec.get(), seq_id, n_accepted);
+        s->pending_proposals[seq_id] = false;
+        s->results[seq_id].clear();
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+extern "C" bool mtp_session_is_quiescent(const mtp_session * s) {
+    return mtp_session_quiescent(s);
+}
+
+extern "C" bool mtp_session_has_pending_proposal(
+        const mtp_session * s,
+        int32_t             seq_id) {
+    return mtp_session_valid_seq(s, seq_id) && s->pending_proposals[seq_id];
+}
+
+extern "C" mtp_state_status mtp_session_state_size(
+        const mtp_session * s,
+        int32_t             seq_id,
+        size_t *            out_size) {
+    if (out_size == nullptr) {
+        return MTP_STATE_STATUS_NULL;
+    }
+    *out_size = 0;
+    try {
+        std::vector<uint8_t> state;
+        const mtp_state_status status = build_state(s, seq_id, state);
+        if (status == MTP_STATE_STATUS_OK) {
+            *out_size = state.size();
+        }
+        return status;
+    } catch (...) {
+        return MTP_STATE_STATUS_EXCEPTION;
+    }
+}
+
+extern "C" mtp_state_status mtp_session_state_get(
+        const mtp_session * s,
+        int32_t             seq_id,
+        uint8_t *           out_data,
+        size_t              capacity,
+        size_t *            out_written) {
+    if (out_written == nullptr) {
+        return MTP_STATE_STATUS_NULL;
+    }
+    *out_written = 0;
+    try {
+        std::vector<uint8_t> state;
+        const mtp_state_status status = build_state(s, seq_id, state);
+        if (status != MTP_STATE_STATUS_OK) {
+            return status;
+        }
+        *out_written = state.size();
+        if (capacity < state.size()) {
+            return MTP_STATE_STATUS_BUFFER_SMALL;
+        }
+        if (!state.empty() && out_data == nullptr) {
+            return MTP_STATE_STATUS_NULL;
+        }
+        if (!state.empty()) {
+            std::memcpy(out_data, state.data(), state.size());
+        }
+        return MTP_STATE_STATUS_OK;
+    } catch (...) {
+        return MTP_STATE_STATUS_EXCEPTION;
+    }
+}
+
+extern "C" mtp_state_status mtp_session_state_set(
+        mtp_session *  s,
+        int32_t        seq_id,
+        const uint8_t * data,
+        size_t          size) {
+    if (s == nullptr || (size > 0 && data == nullptr)) {
+        return MTP_STATE_STATUS_NULL;
+    }
+    if (!mtp_session_valid_seq(s, seq_id)) {
+        return MTP_STATE_STATUS_BAD_SEQUENCE;
+    }
+    if (!mtp_session_quiescent(s)) {
+        return MTP_STATE_STATUS_NOT_QUIESCENT;
+    }
+    try {
+        if (size < MTP_STATE_HEADER_SIZE ||
+                std::memcmp(data, MTP_STATE_MAGIC, sizeof(MTP_STATE_MAGIC)) != 0) {
+            return MTP_STATE_STATUS_INVALID;
+        }
+
+        size_t offset = sizeof(MTP_STATE_MAGIC);
+        uint32_t version = 0;
+        uint32_t state_spec_type = 0;
+        uint32_t state_n_seq = 0;
+        uint32_t state_n_draft_max = 0;
+        uint32_t state_n_min = 0;
+        uint32_t state_p_min_bits = 0;
+        uint32_t state_seq_id = 0;
+        uint32_t prompt_count = 0;
+        uint32_t implementation_size = 0;
+        if (!read_u32(data, size, offset, version) ||
+                !read_u32(data, size, offset, state_spec_type) ||
+                !read_u32(data, size, offset, state_n_seq) ||
+                !read_u32(data, size, offset, state_n_draft_max) ||
+                !read_u32(data, size, offset, state_n_min) ||
+                !read_u32(data, size, offset, state_p_min_bits) ||
+                !read_u32(data, size, offset, state_seq_id) ||
+                !read_u32(data, size, offset, prompt_count) ||
+                !read_u32(data, size, offset, implementation_size)) {
+            return MTP_STATE_STATUS_INVALID;
+        }
+        uint32_t p_min_bits = 0;
+        std::memcpy(&p_min_bits, &s->p_min, sizeof(p_min_bits));
+        if (version != MTP_STATE_VERSION ||
+                state_spec_type != (uint32_t) s->spec_type ||
+                state_n_seq != s->n_seq ||
+                state_n_draft_max != (uint32_t) s->n_draft_max ||
+                state_n_min != (uint32_t) s->n_min ||
+                state_p_min_bits != p_min_bits ||
+                state_seq_id != (uint32_t) seq_id) {
+            return MTP_STATE_STATUS_INVALID;
+        }
+
+        const size_t prompt_bytes = (size_t) prompt_count * sizeof(uint32_t);
+        if (prompt_count != 0 && prompt_bytes / sizeof(uint32_t) != prompt_count ||
+                offset > size || prompt_bytes > size - offset ||
+                implementation_size != size - offset - prompt_bytes) {
+            return MTP_STATE_STATUS_INVALID;
+        }
+
+        llama_tokens prompt;
+        prompt.reserve(prompt_count);
+        for (uint32_t i = 0; i < prompt_count; ++i) {
+            uint32_t token = 0;
+            if (!read_u32(data, size, offset, token)) {
+                return MTP_STATE_STATUS_INVALID;
+            }
+            prompt.push_back((llama_token) token);
+        }
+        std::vector<uint8_t> implementation(
+                data + offset,
+                data + offset + implementation_size);
+        std::vector<uint8_t> previous;
+        if (!common_speculative_get_state(s->spec.get(), seq_id, previous)) {
+            return MTP_STATE_STATUS_UNAVAILABLE;
+        }
+        if (!common_speculative_set_state(s->spec.get(), seq_id, implementation)) {
+            return MTP_STATE_STATUS_INVALID;
+        }
+        std::vector<uint8_t> restored;
+        if (!common_speculative_get_state(s->spec.get(), seq_id, restored) ||
+                restored != implementation) {
+            if (!common_speculative_set_state(s->spec.get(), seq_id, previous)) {
+                return MTP_STATE_STATUS_EXCEPTION;
+            }
+            std::vector<uint8_t> rolled_back;
+            if (!common_speculative_get_state(s->spec.get(), seq_id, rolled_back) ||
+                    rolled_back != previous) {
+                return MTP_STATE_STATUS_EXCEPTION;
+            }
+            return MTP_STATE_STATUS_INVALID;
+        }
+
+        s->prompts[seq_id].swap(prompt);
+        s->results[seq_id].clear();
+        return MTP_STATE_STATUS_OK;
+    } catch (...) {
+        return MTP_STATE_STATUS_EXCEPTION;
+    }
 }
 
 extern "C" void mtp_session_print_stats(const mtp_session * s) {
     if (s == nullptr) {
         return;
     }
-    common_speculative_print_stats(s->spec.get());
+    try {
+        common_speculative_print_stats(s->spec.get());
+    } catch (...) {
+        return;
+    }
 }
 
 extern "C" int32_t mtp_session_n_max(const mtp_session * s) {

--- a/llama-cpp-sys-4/mtp_shim/mtp_shim.h
+++ b/llama-cpp-sys-4/mtp_shim/mtp_shim.h
@@ -33,6 +33,19 @@ enum mtp_spec_type {
     MTP_SPEC_TYPE_EAGLE3 = 1,
 };
 
+// Result of a versioned speculative-state operation.
+enum mtp_state_status {
+    MTP_STATE_STATUS_OK             = 0,
+    MTP_STATE_STATUS_NULL           = 1,
+    MTP_STATE_STATUS_BAD_SEQUENCE   = 2,
+    MTP_STATE_STATUS_NOT_QUIESCENT  = 3,
+    MTP_STATE_STATUS_BUFFER_SMALL   = 4,
+    MTP_STATE_STATUS_UNAVAILABLE    = 5,
+    MTP_STATE_STATUS_INVALID        = 6,
+    MTP_STATE_STATUS_OVERFLOW       = 7,
+    MTP_STATE_STATUS_EXCEPTION      = 8,
+};
+
 struct mtp_session_config {
     uint32_t n_seq;
     int32_t  n_draft_max;
@@ -75,7 +88,7 @@ bool mtp_session_need_embd_pre_norm(const struct mtp_session * s);
 // Optional: call once per fresh generation. `prompt` is the prompt-token array
 // already decoded into the target context (used by ngram-style speculators;
 // MTP currently uses it only for sanity assertions).
-void mtp_session_begin(
+bool mtp_session_begin(
         struct mtp_session * s,
         int32_t              seq_id,
         const llama_token *  prompt,
@@ -98,7 +111,7 @@ bool mtp_session_process(
 // `n_draft_max`).
 // On return: `*out_n_tokens` is set to the number of tokens written, and
 // `out_tokens[0..*out_n_tokens]` holds the draft.
-void mtp_session_draft(
+bool mtp_session_draft(
         struct mtp_session * s,
         int32_t              seq_id,
         llama_pos            n_past,
@@ -110,10 +123,48 @@ void mtp_session_draft(
 // accepted by the target verifier (and that the remainder were rejected).
 // This updates per-sequence carryover state and rolls back the draft context's
 // recurrent state past redundant pre-advancement.
-void mtp_session_accept(
+bool mtp_session_accept(
         struct mtp_session * s,
         int32_t              seq_id,
         uint16_t             n_accepted);
+
+// True only when no sequence has an unaccepted draft proposal.
+bool mtp_session_is_quiescent(const struct mtp_session * s);
+
+// True when `seq_id` has a proposal produced by `mtp_session_draft` that has
+// not yet been completed by `mtp_session_accept`.
+bool mtp_session_has_pending_proposal(
+        const struct mtp_session * s,
+        int32_t                    seq_id);
+
+// Return the exact size of the versioned per-sequence speculative state.
+//
+// State includes the prompt storage owned by this shim and the selected
+// implementation's opaque continuation bytes. It can be captured/restored
+// only while the complete session is quiescent. Target and draft
+// `llama_context` state must be checkpointed separately.
+enum mtp_state_status mtp_session_state_size(
+        const struct mtp_session * s,
+        int32_t                    seq_id,
+        size_t *                   out_size);
+
+// Copy the exact versioned state. On `BUFFER_SMALL`, `out_written` receives the
+// required size and no bytes are written.
+enum mtp_state_status mtp_session_state_get(
+        const struct mtp_session * s,
+        int32_t                    seq_id,
+        uint8_t *                  out_data,
+        size_t                     capacity,
+        size_t *                   out_written);
+
+// Restore exact versioned state. Configuration, strategy, sequence identity,
+// lengths, and the implementation-specific state are all validated before the
+// shim commits its prompt storage.
+enum mtp_state_status mtp_session_state_set(
+        struct mtp_session * s,
+        int32_t              seq_id,
+        const uint8_t *      data,
+        size_t               size);
 
 // Log speculative-decoding statistics via llama.cpp's LOG_INF (draft/accept
 // counts and timings). Requires a log callback if you want to capture output.

--- a/llama-cpp-sys-4/patches/0003-exact-speculative-state.patch
+++ b/llama-cpp-sys-4/patches/0003-exact-speculative-state.patch
@@ -1,0 +1,164 @@
+--- a/common/speculative.cpp
++++ b/common/speculative.cpp
+@@ -169,7 +169,7 @@ struct common_speculative_impl {
+ 
+     // (optional) serialize/restore per-seq internal state (e.g. eagle3's deferred boundary).
+     virtual bool get_state(llama_seq_id /*seq_id*/, std::vector<uint8_t> & /*data*/) const { return false; }
+-    virtual void set_state(llama_seq_id /*seq_id*/, const std::vector<uint8_t> & /*data*/) {}
++    virtual bool set_state(llama_seq_id /*seq_id*/, const std::vector<uint8_t> & /*data*/) { return false; }
+ 
+     // true if this implementation requires the target context to extract post-norm embeddings
+     virtual bool need_embd() const = 0;
+@@ -862,11 +862,12 @@ struct common_speculative_impl_draft_eagle3 : public common_speculative_impl {
+     }
+ 
+     bool get_state(llama_seq_id seq_id, std::vector<uint8_t> & data) const override {
+-        if (!need_boundary_stash()) {
++        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq) {
+             return false;
+         }
+-        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq || pending_pos_last[seq_id] < 0) {
+-            return false;
++        if (!need_boundary_stash()) {
++            data.clear();
++            return true;
+         }
+ 
+         const llama_pos          pos = pending_pos_last[seq_id];
+@@ -878,23 +879,27 @@ struct common_speculative_impl_draft_eagle3 : public common_speculative_impl {
+         return true;
+     }
+ 
+-    void set_state(llama_seq_id seq_id, const std::vector<uint8_t> & data) override {
+-        if (!need_boundary_stash()) {
+-            return;
+-        }
++    bool set_state(llama_seq_id seq_id, const std::vector<uint8_t> & data) override {
+         if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq) {
+-            return;
++            return false;
++        }
++        if (!need_boundary_stash()) {
++            return data.empty();
+         }
+         if (data.size() != sizeof(llama_pos) + (size_t) n_embd_dec * sizeof(float)) {
+-            return;
++            return false;
+         }
+ 
+         llama_pos pos = -1;
+         std::memcpy(&pos, data.data(), sizeof(llama_pos));
++        if (pos < -1) {
++            return false;
++        }
+ 
+         pending_pos_last[seq_id] = pos;
+         pending_g_last[seq_id].resize(n_embd_dec);
+         std::memcpy(pending_g_last[seq_id].data(), data.data() + sizeof(llama_pos), (size_t) n_embd_dec * sizeof(float));
++        return true;
+     }
+ 
+     bool need_embd() const override {
+@@ -1638,6 +1643,69 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
+         std::memcpy(pending_h[seq_id].data(), verify_h[seq_id].data() + (size_t) i_h * n_embd, row_bytes);
+     }
+ 
++    bool get_state(llama_seq_id seq_id, std::vector<uint8_t> & data) const override {
++        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq) {
++            return false;
++        }
++
++        // Versioned local envelope. This remains opaque to callers and is
++        // bound to the exact llama.cpp build identity by the Rust adapter.
++        constexpr uint32_t version = 1;
++        constexpr size_t header_size =
++                sizeof(version) + sizeof(n_embd) + sizeof(n_mtp_layers) + 4;
++        const size_t values_size = (size_t) n_embd * sizeof(float);
++        data.assign(header_size + values_size, 0);
++
++        size_t offset = 0;
++        auto put = [&](const void * src, size_t size) {
++            std::memcpy(data.data() + offset, src, size);
++            offset += size;
++        };
++        put(&version, sizeof(version));
++        put(&n_embd, sizeof(n_embd));
++        put(&n_mtp_layers, sizeof(n_mtp_layers));
++        data[offset++] = is_mem_shared ? 1 : 0;
++        data[offset++] = chain_heads ? 1 : 0;
++        offset += 2; // reserved, already zero
++        put(pending_h[seq_id].data(), values_size);
++        return true;
++    }
++
++    bool set_state(llama_seq_id seq_id, const std::vector<uint8_t> & data) override {
++        constexpr uint32_t expected_version = 1;
++        constexpr size_t header_size =
++                sizeof(expected_version) + sizeof(n_embd) + sizeof(n_mtp_layers) + 4;
++        const size_t values_size = (size_t) n_embd * sizeof(float);
++        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq ||
++                data.size() != header_size + values_size) {
++            return false;
++        }
++
++        uint32_t version = 0;
++        int32_t state_n_embd = 0;
++        int32_t state_n_mtp_layers = 0;
++        size_t offset = 0;
++        auto get = [&](void * dst, size_t size) {
++            std::memcpy(dst, data.data() + offset, size);
++            offset += size;
++        };
++        get(&version, sizeof(version));
++        get(&state_n_embd, sizeof(state_n_embd));
++        get(&state_n_mtp_layers, sizeof(state_n_mtp_layers));
++        const bool state_is_mem_shared = data[offset++] != 0;
++        const bool state_chain_heads = data[offset++] != 0;
++        const bool reserved_zero = data[offset++] == 0 && data[offset++] == 0;
++        if (version != expected_version || state_n_embd != n_embd ||
++                state_n_mtp_layers != n_mtp_layers ||
++                state_is_mem_shared != is_mem_shared ||
++                state_chain_heads != chain_heads || !reserved_zero) {
++            return false;
++        }
++
++        std::memcpy(pending_h[seq_id].data(), data.data() + offset, values_size);
++        return true;
++    }
++
+     bool need_embd() const override {
+         return false;
+     }
+@@ -2671,14 +2739,18 @@ bool common_speculative_get_state(common_speculative * spec, llama_seq_id seq_id
+     return false;
+ }
+ 
+-void common_speculative_set_state(common_speculative * spec, llama_seq_id seq_id, const std::vector<uint8_t> & data) {
++bool common_speculative_set_state(common_speculative * spec, llama_seq_id seq_id, const std::vector<uint8_t> & data) {
+     if (spec == nullptr) {
+-        return;
++        return false;
+     }
+ 
+     for (auto & impl : spec->impls) {
+-        impl->set_state(seq_id, data);
++        if (impl->set_state(seq_id, data)) {
++            return true;
++        }
+     }
++
++    return false;
+ }
+ 
+ void common_speculative_print_stats(const common_speculative * spec) {
+--- a/common/speculative.h
++++ b/common/speculative.h
+@@ -72,7 +72,7 @@ void common_speculative_accept(common_speculative * spec, llama_seq_id, uint16_t
+ 
+ // (optional) get/set internal state
+ bool common_speculative_get_state(common_speculative * spec, llama_seq_id seq_id, std::vector<uint8_t> & data);
+-void common_speculative_set_state(common_speculative * spec, llama_seq_id seq_id, const std::vector<uint8_t> & data);
++bool common_speculative_set_state(common_speculative * spec, llama_seq_id seq_id, const std::vector<uint8_t> & data);
+ 
+ // print statistics about the speculative decoding
+ void common_speculative_print_stats(const common_speculative * spec);

--- a/llama-cpp-sys-4/patches/0004-exact-decode-lifecycle-hooks.patch
+++ b/llama-cpp-sys-4/patches/0004-exact-decode-lifecycle-hooks.patch
@@ -1,0 +1,83 @@
+diff --git a/include/llama.h b/include/llama.h
+index 3c6d22be8..756ee1d1c 100644
+--- a/include/llama.h
++++ b/include/llama.h
+@@ -344,6 +344,16 @@ extern "C" {
+         struct llama_sampler * sampler;
+     };
+ 
++    // Exact decode lifecycle hooks used by safe callback owners. The begin
++    // callback runs before native state mutation. The end callback runs after
++    // every attempted decode and receives whether native decode succeeded.
++    typedef bool (*llama_decode_begin_callback)(
++            const struct llama_batch * batch,
++            void * user_data);
++    typedef bool (*llama_decode_end_callback)(
++            bool native_succeeded,
++            void * user_data);
++
+     // NOTE: changing the default values of parameters marked as [EXPERIMENTAL] may cause crashes or incorrect results in certain configurations
+     //       https://github.com/ggml-org/llama.cpp/pull/7544
+     struct llama_context_params {
+@@ -374,6 +384,8 @@ extern "C" {
+ 
+         ggml_backend_sched_eval_callback cb_eval;
+         void * cb_eval_user_data;
++        llama_decode_begin_callback cb_decode_begin;
++        llama_decode_end_callback   cb_decode_end;
+ 
+         enum ggml_type type_k; // data type for K cache [EXPERIMENTAL]
+         enum ggml_type type_v; // data type for V cache [EXPERIMENTAL]
+diff --git a/src/llama-context.cpp b/src/llama-context.cpp
+index 9b399d609..fde26f0c2 100644
+--- a/src/llama-context.cpp
++++ b/src/llama-context.cpp
+@@ -136,6 +136,8 @@ llama_context::llama_context(
+ 
+     cparams.cb_eval           = params.cb_eval;
+     cparams.cb_eval_user_data = params.cb_eval_user_data;
++    cparams.cb_decode_begin   = params.cb_decode_begin;
++    cparams.cb_decode_end     = params.cb_decode_end;
+ 
+     cparams.ctx_other = nullptr;
+ 
+@@ -3489,6 +3491,8 @@ llama_context_params llama_context_default_params() {
+         /*.defrag_thold                =*/ -1.0f,
+         /*.cb_eval                     =*/ nullptr,
+         /*.cb_eval_user_data           =*/ nullptr,
++        /*.cb_decode_begin             =*/ nullptr,
++        /*.cb_decode_end               =*/ nullptr,
+         /*.type_k                      =*/ GGML_TYPE_F16,
+         /*.type_v                      =*/ GGML_TYPE_F16,
+         /*.abort_callback              =*/ nullptr,
+@@ -4074,7 +4078,17 @@ int32_t llama_encode(
+ int32_t llama_decode(
+         llama_context * ctx,
+           llama_batch   batch) {
++    const auto & cparams = ctx->get_cparams();
++    if (cparams.cb_decode_begin &&
++            !cparams.cb_decode_begin(&batch, cparams.cb_eval_user_data)) {
++        return -4;
++    }
++
+     const int ret = ctx->decode(batch);
++    if (cparams.cb_decode_end &&
++            !cparams.cb_decode_end(ret == 0, cparams.cb_eval_user_data)) {
++        return -4;
++    }
+     if (ret != 0 && ret != 1) {
+         LLAMA_LOG_ERROR("%s: failed to decode, ret = %d\n", __func__, ret);
+     }
+diff --git a/src/llama-cparams.h b/src/llama-cparams.h
+index 5018170ed..2ee790b79 100644
+--- a/src/llama-cparams.h
++++ b/src/llama-cparams.h
+@@ -60,6 +60,8 @@ struct llama_cparams {
+ 
+     ggml_backend_sched_eval_callback cb_eval;
+     void * cb_eval_user_data;
++    llama_decode_begin_callback cb_decode_begin;
++    llama_decode_end_callback   cb_decode_end;
+ 
+     llama_context * ctx_other;
+ };

--- a/llama-cpp-sys-4/patches/0005-fail-closed-eagle3-process.patch
+++ b/llama-cpp-sys-4/patches/0005-fail-closed-eagle3-process.patch
@@ -1,0 +1,24 @@
+--- a/common/speculative.cpp
++++ b/common/speculative.cpp
+@@ -613,7 +613,9 @@ struct common_speculative_impl_draft_eagle3 : public common_speculative_impl {
+                 ? llama_get_embeddings_layer_inp(ctx_tgt, (uint32_t) target_layer_ids[k])
+                 : llama_get_embeddings_nextn(ctx_tgt);
+             if (!layer) {
+-                GGML_ABORT("EAGLE3: target layer %d input not extracted.", target_layer_ids[k]);
++                SPC_ERR("EAGLE3: target layer %d input not extracted.\n",
++                        target_layer_ids[k]);
++                return false;
+             }
+             for (int32_t i = 0; i < n_tokens; ++i) {
+                 float * dst = features_buf.data() + (size_t) i * n_embd_enc + k * (size_t) n_embd_tgt;
+@@ -648,6 +650,9 @@ struct common_speculative_impl_draft_eagle3 : public common_speculative_impl {
+             // g_embd has shape [n_chunk, n_embd_dec] in ctx_dft's pre-norm embeddings buffer.
+             const float * g_embd_chunk = llama_get_embeddings_nextn(ctx_dft);
+-            GGML_ASSERT(g_embd_chunk && "EAGLE3 encoder produced no output.");
++            if (!g_embd_chunk) {
++                SPC_ERR("%s\n", "EAGLE3 encoder produced no output.");
++                return false;
++            }
+             std::memcpy(g_embd_buf.data() + (size_t) i * n_embd_dec,
+                         g_embd_chunk,
+                         (size_t) n_chunk * n_embd_dec * sizeof(float));

--- a/llama-cpp-sys-4/src/lib.rs
+++ b/llama-cpp-sys-4/src/lib.rs
@@ -4,7 +4,11 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-#[allow(unnecessary_transmutes)]
+#[allow(
+    unnecessary_transmutes,
+    clippy::missing_safety_doc,
+    clippy::ptr_offset_with_cast
+)]
 mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }


### PR DESCRIPTION
## What changed

- Adds an owned, pinned tensor-transaction callback surface with exact
  selectors, bounded capture, transactional finite `f32` write-back, decode
  lifecycle hooks, panic/error containment, and a written safety contract.
- Makes MTP and EAGLE-3 sessions lifetime-bound and non-thread-transferable,
  validates target/draft topology and capacity before native allocation,
  contains C++ failures, and adds exact quiescent continuation-state
  capture/restore.
- Adds allocation-reusing tokenization and raw-piece sinks plus count-only
  tokenization.
- Forward-ports the binding and native patches to llama.cpp
  `f87067841bac583bc089a225382248d857791ca8`, tightens patched-source/prebuilt
  handling, and updates the MTP/EAGLE examples and documentation.

## Why

The current safe surface does not represent the ownership, causal decode
boundaries, and implementation state needed for exact speculative continuation
or bounded graph-node transforms. These changes move that responsibility into
the binding: callers get checked Rust contracts while raw tensor pointers,
native callback state, and C++ exception handling remain inside the
sys/binding boundary.

## Compatibility

This is intentionally breaking within the pre-1.0 line:

- `MtpSession` and `Eagle3Session` now exclusively borrow mutable target/draft
  contexts and return typed lifecycle errors.
- `LlamaContextParams::with_tensor_capture` is now `unsafe`; the owned
  `with_tensor_transactions` path is the safe replacement.

The changelog now calls these changes out directly.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p llama-cpp-4 --lib --locked -- -D warnings`
- `cargo build --workspace --all-targets --locked`
- `cargo test --workspace --exclude openai-server --locked`
- 33 focused binding unit tests, the workspace integration/unit suites, and
  116 rustdoc tests passed; 21 rustdoc examples remain intentionally ignored.
- The source build applied all three native patches successfully against the
  pinned llama.cpp revision.

No caller-supplied GGUF was used, so this establishes source/build and
model-free contract behavior rather than model-backed performance or output
quality.